### PR TITLE
Fix uninitialized constant React::JSX::Tilt in 3.2.x

### DIFF
--- a/lib/react/jsx/template.rb
+++ b/lib/react/jsx/template.rb
@@ -1,3 +1,5 @@
+require 'tilt'
+
 module React
   module JSX
 


### PR DESCRIPTION
Fix for Rails 3.2.x one again.
