### PR TITLE
update README version to 0.8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ As with all gem dependencies, we strongly recommend adding `react-rails` to your
 ```ruby
 # Gemfile
 
-gem 'react-rails', '~> 0.4.1.0'
+gem 'react-rails', '~> 0.8.0.0'
 ```
 
 


### PR DESCRIPTION
If a developer discovers `react-rails` through Github, they'll probably use whatever version number is listed on the README. For that reason, most Rails projects keep the README version number up-to-date so that folks don't accidentally install old versions.
