### PR TITLE
Components to global name space for coffee

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ It is possible to use JSX with CoffeeScript. The caveat is that you will still n
 ```coffee
 ###* @jsx React.DOM ###
 
-Component = React.createClass
+window.Component = React.createClass
   render: ->
     `<ExampleComponent videos={this.props.videos} />`
 ```


### PR DESCRIPTION
Coffee puts code to closures. React components must be in global namespace.
