### PR TITLE
Implement server-side rendering

### DIFF
--- a/lib/react-rails.rb
+++ b/lib/react-rails.rb
@@ -1,3 +1,4 @@
 require 'react/jsx'
+require 'react/renderer'
 require 'react/rails'
 

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -8,6 +8,16 @@ module React
       # Sensible defaults. Can be overridden in application.rb
       config.react.variant = (::Rails.env.production? ? :production : :development)
       config.react.addons = false
+      # Server-side rendering
+      config.react.max_renderers = 10
+      config.react.timeout = 20 #seconds
+      config.react.react_js = lambda {File.read(::Rails.application.assets.resolve('react.js'))}
+      config.react.component_filenames = ['components.js']
+
+      # Watch .jsx files for changes in dev, so we can reload the JS VMs with the new JS code.
+      initializer "react_rails.add_watchable_files" do |app|
+        app.config.watchable_files.concat Dir["#{app.root}/app/assets/javascripts/**/*.jsx*"]
+      end
 
       # run after all initializers to allow sprockets to pick up react.js and
       # jsxtransformer.js from end-user to override ours if needed
@@ -37,11 +47,32 @@ module React
         app.assets.prepend_path dropin_path if dropin_path.exist?
 
         # Allow overriding react files that are based on environment
-        # e.g. /vendor/assets/react/react.js
+        # e.g. /vendor/assets/react/development/react.js
         dropin_path_env = app.root.join("vendor/assets/react/#{app.config.react.variant}")
         app.assets.prepend_path dropin_path_env if dropin_path_env.exist?
-
       end
+
+
+      config.after_initialize do |app|
+        # Server Rendering
+        # Concat component_filenames together for server rendering
+        app.config.react.components_js = app.config.react.component_filenames.map do |filename|
+          app.assets[filename].to_s
+        end.join(";")
+
+        do_setup = lambda do
+          cfg = app.config.react
+          React::Renderer.setup!( cfg.react_js.call, cfg.components_js,
+                                {:size => cfg.size, :timeout => cfg.timeout})
+        end
+
+        do_setup.call
+
+        # Reload the JS VMs in dev when files change
+        ActionDispatch::Reloader.to_prepare(&do_setup)
+      end
+
+
     end
   end
 end

--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -1,39 +1,14 @@
 module React
   module Rails
     module ViewHelper
-      # Render a react component named +name+. Returns a HTML tag and some
-      # javascript to render the component.
+
+      # Render a UJS-type HTML tag annotated with data attributes, which
+      # are used by react_ujs to actually instantiate the React component
+      # on the client.
       #
-      # HTML attributes can be specified by +options+. The HTML tag is +div+
-      # by default and can be changed by +options[:tag]+. If +options+ is a
-      # symbol, use it as +options[:tag]+.
-      #
-      # Static child elements can be rendered by using a block. Be aware that
-      # they will be replaced once javascript gets executed.
-      #
-      # ==== Examples
-      #
-      #   # // <HelloMessage> defined in a .jsx file:
-      #   # var HelloMessage = React.createClass({
-      #   #   render: function() {
-      #   #     return <div>{'Hello ' + this.props.name}</div>;
-      #   #   }
-      #   # });
-      #   react_component(:HelloMessage, :name => 'John')
-      #
-      #   # Use <span> instead of <div>:
-      #   react_component(:HelloMessage, {:name => 'John'}, :span)
-      #   react_component(:HelloMessage, {:name => 'John'}, :tag => :span)
-      #
-      #   # Add HTML attributes:
-      #   react_component(:HelloMessage, {}, {:class => 'c', :id => 'i'})
-      #
-      #   # (ERB) Customize child elements:
-      #   <%= react_component :HelloMessage do -%>
-      #     Loading...
-      #   <% end -%>
       def react_component(name, args = {}, options = {}, &block)
         options = {:tag => options} if options.is_a?(Symbol)
+        block = Proc.new{React::Renderer.render(name, args)} if options[:prerender] == true
 
         html_options = options.reverse_merge(:data => {})
         html_options[:data].tap do |data|
@@ -44,6 +19,7 @@ module React
 
         content_tag(html_tag, '', html_options, &block)
       end
+
     end
   end
 end

--- a/lib/react/renderer.rb
+++ b/lib/react/renderer.rb
@@ -1,0 +1,51 @@
+require 'connection_pool'
+
+module React
+  class Renderer
+
+    cattr_accessor :pool
+
+    def self.setup!(react_js, components_js, args={})
+      args.assert_valid_keys(:size, :timeout)
+      @@react_js = react_js
+      @@components_js = components_js
+      @@pool.shutdown{} if @@pool
+      @@pool = ConnectionPool.new(:size => args[:size]||10, :timeout => args[:timeout]||20) { self.new }
+    end
+
+    def self.render(component, args={})
+      @@pool.with do |renderer|
+        renderer.render(component, args)
+      end
+    end
+
+    def self.combined_js
+      @@combined_js ||= <<-CODE
+        var global = global || this;
+        #{@@react_js};
+        React = global.React;
+        #{@@components_js};
+      CODE
+    end
+
+    def context
+      @context ||= ExecJS.compile(self.class.combined_js)
+    end
+
+    def render(component, args={})
+      jscode = <<-JS
+        function() {
+          return React.renderComponentToString(#{component}(#{args.to_json}));
+        }()
+      JS
+      context.eval(jscode).html_safe
+    # What should be done here? If we are server rendering, and encounter an error in the JS code,
+    # then log it and continue, which will just render the react ujs tag, and when the browser tries
+    # to render the component it will most likely encounter the same error and throw to the browser
+    # console for a better debugging experience.
+    rescue ExecJS::ProgramError => e
+      ::Rails.logger.error "[React::Renderer] #{e.message}"
+    end
+
+  end
+end

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'execjs'
   s.add_dependency 'rails', '>= 3.1'
   s.add_dependency 'react-source', '0.9.0'
+  s.add_dependency 'connection_pool'
 
   s.files = Dir[
     'lib/**/*',

--- a/test/dummy/app/assets/javascripts/components.js
+++ b/test/dummy/app/assets/javascripts/components.js
@@ -1,0 +1,8 @@
+//= require_self
+//= require_tree ./components
+
+// This is because we compile this file into a JS VM
+// for server rendering, and some components may be
+// .coffee and wrapped in a func, so they need a
+// global to glom on to.
+var self, window, global = global || window || self;

--- a/test/dummy/app/assets/javascripts/components/Todo.js.jsx.coffee
+++ b/test/dummy/app/assets/javascripts/components/Todo.js.jsx.coffee
@@ -1,0 +1,9 @@
+###* @jsx React.DOM ###
+
+Todo = React.createClass
+  render: ->
+    `<li>{this.props.todo}</li>`
+
+# Because Coffee files are in an anonymous function,
+# expose it for server rendering tests
+global.Todo = Todo

--- a/test/dummy/app/assets/javascripts/components/TodoList.js.jsx
+++ b/test/dummy/app/assets/javascripts/components/TodoList.js.jsx
@@ -1,0 +1,21 @@
+/** @jsx React.DOM */
+
+TodoList = React.createClass({
+  getInitialState: function() {
+    return({mounted: "nope"});
+  },
+  componentWillMount: function() {
+    this.setState({mounted: 'yep'});
+  },
+  render: function() {
+    return (
+      <ul>
+        <li id='status'>{this.state.mounted}</li>
+        {this.props.todos.map(function(todo, i) {
+          return (<Todo key={i} todo={todo} />)
+        })}
+      </ul>
+    )
+  }
+})
+

--- a/test/dummy/app/controllers/server_controller.rb
+++ b/test/dummy/app/controllers/server_controller.rb
@@ -1,0 +1,5 @@
+class ServerController < ApplicationController
+  def show
+    @todos = %w{todo1 todo2 todo3}
+  end
+end

--- a/test/dummy/app/views/server/show.html.erb
+++ b/test/dummy/app/views/server/show.html.erb
@@ -1,0 +1,1 @@
+<%= react_component "TodoList", {:todos => @todos}, :prerender => true %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Dummy::Application.routes.draw do
   resources :pages, :only => [:show]
+  resources :server, :only => [:show]
 end

--- a/test/react_renderer_test.rb
+++ b/test/react_renderer_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ReactRendererTest < ActiveSupport::TestCase
+
+  test 'Server rendering class directly' do
+    result = React::Renderer.render "TodoList", :todos => %w{todo1 todo2 todo3}
+    assert_match /todo1.*todo2.*todo3/, result
+    assert_match /data-react-checksum/, result
+  end
+
+end

--- a/test/view_helper_test.rb
+++ b/test/view_helper_test.rb
@@ -6,6 +6,14 @@ require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 Capybara.app = Rails.application
 
+# Useful for debugging.
+# Just put page.driver.debug in your test and it will
+# pause and throw up a browser
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, :inspector => true)
+end
+Capybara.javascript_driver = :poltergeist_debug
+
 class ViewHelperTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
@@ -63,5 +71,12 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
 
     page.click_link('Bob')
     assert page.has_content?('Hello Bob')
+  end
+
+  test 'react server rendering also gets mounted on client' do
+    visit '/server/1'
+    assert_match /data-react-class=\"TodoList\"/, page.html
+    assert_match /data-react-checksum/, page.html
+    assert_match /yep/, page.find("#status").text
   end
 end


### PR DESCRIPTION
Add an additional view helper `react_server_component` with the same interface/functionality as `react_component` with the exception that the body of the tag will be filled with a server rendering of the HTML markup. (Im not sure if it should be a different method name or perhaps just an argument to `react_component`? )

For thread-safety we use the ConnectionPool class from @mperham to control access to the JS VMs.  It is performing well under load in my tests.
