### PR TITLE
fix version for rubygems

### DIFF
--- a/lib/react/rails/version.rb
+++ b/lib/react/rails/version.rb
@@ -1,5 +1,5 @@
 module React
   module Rails
-    VERSION = '1.0.0-pre'
+    VERSION = '1.0.0.pre'
   end
 end


### PR DESCRIPTION
rubygems versioning doesn't support the dash, so e.g. trying to install this gem via bundler will fail with "Malformed version number string 1.0.0-pre"
