### PR TITLE
Fix tests for react-source 0.9

### DIFF
--- a/test/jsxtransform_test.rb
+++ b/test/jsxtransform_test.rb
@@ -15,6 +15,7 @@ EXPECTED_JS_2 = <<eos
   var Component;
 
   Component = React.createClass({
+    displayName:'Component',
     render: function() {
       return ExampleComponent( {videos:this.props.videos} );
     }


### PR DESCRIPTION
Tests were not passing due to some changes in `React.js` itself after upgrading 0.8 -> 0.9.
