### PR TITLE
Initialize railtie for all groups

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -11,7 +11,7 @@ module React
 
       # run after all initializers to allow sprockets to pick up react.js and
       # jsxtransformer.js from end-user to override ours if needed
-      initializer "react_rails.setup_vendor", :after => "sprockets.environment", :group => :all do |app|
+      initializer "react_rails.setup_vendor", :after => "sprockets.environment", :group => :assets do |app|
         # Mimic behavior of ember-rails...
         # We want to include different files in dev/prod. The unminified builds
         # contain console logging for invariants and logging to help catch

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -11,7 +11,7 @@ module React
 
       # run after all initializers to allow sprockets to pick up react.js and
       # jsxtransformer.js from end-user to override ours if needed
-      initializer "react_rails.setup_vendor", :after => "sprockets.environment" do |app|
+      initializer "react_rails.setup_vendor", :after => "sprockets.environment", :group => :all do |app|
         # Mimic behavior of ember-rails...
         # We want to include different files in dev/prod. The unminified builds
         # contain console logging for invariants and logging to help catch


### PR DESCRIPTION
Without `:group => :all` you can't `rake assets:precompile` when you
have `config.initialize_on_precompile = false`.

I'm not sure if there are any downsides for doing this but it seems to be working fine for us.