### PR TITLE
Remount components on page:restore event

### DIFF
--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -59,7 +59,7 @@
     }
     handleEvent('page:load', mountReactComponents);
     // Support for back button
-    handleEvent('"page:restore"', mountReactComponents);
+    handleEvent('page:restore', mountReactComponents);
     handleEvent('page:before-change', unmountReactComponents);
   }
 })(document, window, React);


### PR DESCRIPTION
I noticed that the react components aren't mounted again if you use the back button. I think this should fix it.
