### PR TITLE
Prevent a NameError when loading outside of Rails

### DIFF
--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -24,6 +24,8 @@ module React
   end
 end
 
-ActionView::Base.class_eval do
-  include ::React::Rails::ViewHelper
+module ActionView
+  class Base
+    include ::React::Rails::ViewHelper
+  end
 end


### PR DESCRIPTION
When running `bundle console` we get this error:

```
>>: bundle console
Resolving dependencies...
./lib/react/rails/view_helper.rb:27:in `<top (required)>': uninitialized constant ActionView (NameError)
...
```

I could have also checked with `defined? ActionView::Base` before including, but this would mean that if `ActionView::Base` was defined elsewhere later, the react rails helpers would not be included.
