### PR TITLE
remove internally used properties before server render

### DIFF
--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -15,8 +15,11 @@ module React
           data[:react_class] = name
           data[:react_props] = args.to_json unless args.empty?
         end
-        html_tag = html_options.delete(:tag) || :div
-
+        html_tag = html_options[:tag] || :div
+        
+        # remove internally used properties so they aren't rendered to DOM
+        [:tag, :prerender].each{|prop| html_options.delete(prop)}
+        
         content_tag(html_tag, '', html_options, &block)
       end
 

--- a/test/view_helper_test.rb
+++ b/test/view_helper_test.rb
@@ -83,4 +83,10 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
     assert_match /data-react-checksum/, page.html
     assert_match /yep/, page.find("#status").text
   end
+  
+  test 'react server rendering does not include internal properties' do
+    visit '/server/1'
+    assert_no_match /tag=/, page.html
+    assert_no_match /prerender=/, page.html
+  end
 end


### PR DESCRIPTION
(also adds a test for spilling the internal properties to the DOM)

Example of how it looked before:
![screen shot 2014-07-21 at 15 54 51](https://cloud.githubusercontent.com/assets/134942/3645415/34ae0d20-10ea-11e4-9095-d69bc4a74af6.png)
