### PR TITLE
Load the view helper only if the action view base is loaded

### DIFF
--- a/lib/react/rails.rb
+++ b/lib/react/rails.rb
@@ -1,3 +1,3 @@
 require 'react/rails/railtie'
 require 'react/rails/engine'
-require 'react/rails/view_helper'
+require 'react/rails/view_helper' if defined? ActionView::Base


### PR DESCRIPTION
As an alternative solution to https://github.com/reactjs/react-rails/pull/61
