### PR TITLE
[#75] Fix a timing bug with poltergeist/turbolinks

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,3 +22,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 if ActiveSupport::TestCase.method_defined?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 end
+
+def wait_for_turbolinks_to_be_available
+  sleep(1)
+end

--- a/test/view_helper_test.rb
+++ b/test/view_helper_test.rb
@@ -62,9 +62,13 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
     page.execute_script('history.back();')
     assert page.has_content?('Hello Alice')
 
+    wait_for_turbolinks_to_be_available()
+
     # Try Turbolinks javascript API.
     page.execute_script('Turbolinks.visit("/pages/2");')
     assert page.has_content?('Hello Alice')
+
+    wait_for_turbolinks_to_be_available()
 
     page.execute_script('Turbolinks.visit("/pages/1");')
     assert page.has_content?('Hello Bob')


### PR DESCRIPTION
There's a timing bug in ViewHelperTest that randomly results in
`ReferenceError: Turbolinks Not Found`. This causes unrelated builds
to fail, which gums up the whole open source works.

Per https://github.com/teampoltergeist/poltergeist#timing-problems, the
suggested way of fixing this is to just add calls to sleep.

If you wish to test this in the future, use the shell code:

`for i in `seq 1 10`; do rake appraisal; done`

This should give you enough test runs to hit the timing bug at least
once.
