### PR TITLE
Make sure to only mount components once per DOM node

### DIFF
--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -6,6 +6,10 @@
   // jQuery is optional. Use it to support legacy browsers.
   var $ = (typeof jQuery !== 'undefined') && jQuery;
 
+  // Maps DOM nodes to booleans specifying whether or not those
+  // nodes already have a component mounted in them
+  var mounted = {};
+
   var findReactDOMNodes = function() {
     var SELECTOR = '[' + CLASS_NAME_ATTR + ']';
     if ($) {
@@ -25,7 +29,11 @@
       var constructor = window[className] || eval.call(window, className);
       var propsJson = node.getAttribute(PROPS_ATTR);
       var props = propsJson && JSON.parse(propsJson);
-      React.renderComponent(constructor(props), node);
+
+      if (!mounted[node]) {
+        React.renderComponent(constructor(props), node);
+        mounted[node] = true;
+      }
     }
   };
 
@@ -33,6 +41,7 @@
     var nodes = findReactDOMNodes();
     for (var i = 0; i < nodes.length; ++i) {
       React.unmountComponentAtNode(nodes[i]);
+      delete mounted[node];
     }
   };
 


### PR DESCRIPTION
I've been encountering an issue where on initial page load the event
handler for `page:change` was getting fired twice, causing the React
components to be mounted twice, which caused all sorts of trouble. This
introduces a simple map of DOM nodes to booleans that acts as a guard
against nodes getting components mounted to them more than once.
