### PR TITLE
When using turbolinks, unmount components just before loading the new page

### DIFF
--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -48,7 +48,7 @@
       }
     }
     handleEvent('page:change', mountReactComponents);
-    handleEvent('page:before-change', unmountReactComponents);
+    handleEvent('page:receive', unmountReactComponents);
   };
 
   var handleNativeEvents = function() {


### PR DESCRIPTION
I'm migrating my project to React & Turbolinks. I have a non-optimized page which exposed this issue. 

I think the `react_ujs` unmounts components sooner than it has to. It unmounts on `page:before-change`, but I think it could wait until `page:receive`. 

Here's the difference it made for me.  In the GIF below, the chart & list of times is a React component. The "stations" link is another page that takes a long time to load.
## `page:before-change`

Notice the blank state while it waits for the page from the server.

![earlier_unload](https://cloud.githubusercontent.com/assets/2231765/4158757/9ec26dac-3492-11e4-9089-acf7ee1eef5e.gif)
## `page:receive`

The components are left around til the new page gets here. 

![later_unload](https://cloud.githubusercontent.com/assets/2231765/4158758/9ec7b2bc-3492-11e4-8639-030a58284a80.gif)

What do you think? Is there a downside to this?
