### PR TITLE
Raise any JS error when prerendering

### DIFF
--- a/lib/react/renderer.rb
+++ b/lib/react/renderer.rb
@@ -3,6 +3,13 @@ require 'connection_pool'
 module React
   class Renderer
 
+    class PrerenderError < RuntimeError
+      def initialize(component_name, props, js_message)
+        message = "Encountered error \"#{js_message}\" when prerendering #{component_name} with #{props.to_json}"
+        super(message)
+      end
+    end
+
     cattr_accessor :pool
 
     def self.setup!(react_js, components_js, args={})
@@ -56,13 +63,8 @@ module React
         }()
       JS
       context.eval(jscode).html_safe
-    # What should be done here? If we are server rendering, and encounter an error in the JS code,
-    # then log it and continue, which will just render the react ujs tag, and when the browser tries
-    # to render the component it will most likely encounter the same error and throw to the browser
-    # console for a better debugging experience.
     rescue ExecJS::ProgramError => e
-      ::Rails.logger.error "[React::Renderer] #{e.message}"
+      raise PrerenderError.new(component, args, e)
     end
-
   end
 end

--- a/test/react_renderer_test.rb
+++ b/test/react_renderer_test.rb
@@ -15,4 +15,12 @@ class ReactRendererTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'prerender errors are thrown' do
+    err = assert_raises React::Renderer::PrerenderError do
+      React::Renderer.render("NonexistentComponent", {error: true, exists: false})
+    end
+    expected_message = 'Encountered error "ReferenceError: NonexistentComponent is not defined" when prerendering NonexistentComponent with {"error":true,"exists":false}'
+    assert_equal expected_message, err.message
+  end
 end


### PR DESCRIPTION
A simple attempt at solving #42. Even with better_errors it's not pretty:

![image](https://cloud.githubusercontent.com/assets/2231765/4274518/a48b0068-3cf4-11e4-8ba4-78270308e522.png)

But I'm not sure what else can be done.  Have a look at how `ProgramError` is raised: https://github.com/sstephenson/execjs/search?utf8=%E2%9C%93&q=ProgramError

It looks like it only comes with a `message` -- no stack trace. Any ideas on how to make this more useful?
