### PR TITLE
Only use turbolinks events if supported

### DIFF
--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -61,5 +61,9 @@
     }
   };
 
-  typeof Turbolinks !== 'undefined' ? handleTurbolinksEvents() : handleNativeEvents();
+  if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+    handleTurbolinksEvents();
+  } else {
+    handleNativeEvents();
+  }
 })(document, window, React);


### PR DESCRIPTION
The current code always uses Turbolinks events if it is loaded, but this
doesn't mean it is supported by the browser. This change checks if
turbolinks is supported and otherwise uses the native event handlers.

Without this fix ujs components are not rendered in IE8.