### PR TITLE
Reload all dependent JS when files change

### DIFF
--- a/lib/react/rails.rb
+++ b/lib/react/rails.rb
@@ -1,3 +1,4 @@
 require 'react/rails/railtie'
 require 'react/rails/engine'
+require 'react/rails/reloader'
 require 'react/rails/view_helper'

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -63,7 +63,7 @@ module React
         # Server Rendering
 
         # Concat component_filenames together for server rendering
-        component_source = lambda {
+        combined_components_source = lambda {
           app.config.react.component_filenames.map do |filename|
             app.assets[filename].to_s
           end.join(";")
@@ -80,7 +80,7 @@ module React
 
         setup_renderer = lambda do
           cfg = app.config.react
-          React::Renderer.setup!( react_source, component_source,
+          React::Renderer.setup!( react_source, combined_components_source,
                                 {:size => cfg.size, :timeout => cfg.timeout})
 
           # Update the watch file list with the latest set of dependencies

--- a/lib/react/rails/reloader.rb
+++ b/lib/react/rails/reloader.rb
@@ -1,0 +1,32 @@
+require 'rails'
+
+module React
+  module Rails
+
+    class Reloader
+      def self.on_change(watch_files, &block)
+        unless block_given?
+          warn "Reloader.on_change requires a callback block"
+        end
+
+        @@file_checker = ActiveSupport::FileUpdateChecker.new(watch_files, &block)
+      end
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        execute_if_updated!
+        @app.call(env)
+      end
+
+      private
+
+      def execute_if_updated!
+        @@file_checker.execute_if_updated if @@file_checker
+      end
+    end
+
+  end
+end

--- a/lib/react/rails/reloader.rb
+++ b/lib/react/rails/reloader.rb
@@ -5,10 +5,6 @@ module React
 
     class Reloader
       def self.on_change(watch_files, &block)
-        unless block_given?
-          warn "Reloader.on_change requires a callback block"
-        end
-
         @@file_checker = ActiveSupport::FileUpdateChecker.new(watch_files, &block)
       end
 

--- a/test/dummy/app/assets/javascripts/components/TodoList.js.jsx
+++ b/test/dummy/app/assets/javascripts/components/TodoList.js.jsx
@@ -8,8 +8,11 @@ TodoList = React.createClass({
     this.setState({mounted: 'yep'});
   },
   render: function() {
+    var header = window.todoHeader ? window.todoHeader() : null;
+
     return (
       <ul>
+        {header}
         <li id='status'>{this.state.mounted}</li>
         {this.props.todos.map(function(todo, i) {
           return (<Todo key={i} todo={todo} />)

--- a/test/helper_files/components_with_updates.js
+++ b/test/helper_files/components_with_updates.js
@@ -1,0 +1,3 @@
+//= require_self
+//= require todo-helper
+//= require_tree ./components

--- a/test/helper_files/todo-helper.js
+++ b/test/helper_files/todo-helper.js
@@ -1,0 +1,3 @@
+window.todoHeader = function() {
+  return "<li>Injected Header</li>";
+};

--- a/test/server_rendered_html_test.rb
+++ b/test/server_rendered_html_test.rb
@@ -34,4 +34,39 @@ class ServerRenderedHtmlTest  < ActionDispatch::IntegrationTest
       FileUtils.touch app_file
     end
   end
+
+  test 'react server rendering picks up new files to reload' do
+    helper_update_file = File.expand_path('../helper_files/todo-helper.js', __FILE__)
+    helper_app_file = File.expand_path('../dummy/app/assets/javascripts/todo-helper.js', __FILE__)
+
+    components_with_updates = File.expand_path('../helper_files/components_with_updates.js', __FILE__)
+    components_without_updates = File.expand_path('../helper_files/components_without_updates.js', __FILE__)
+    components_app_file = File.expand_path('../dummy/app/assets/javascripts/components.js', __FILE__)
+
+    FileUtils.cp components_app_file, components_without_updates
+    FileUtils.touch components_app_file
+
+    begin
+      get '/server/1'
+      refute_match 'Updated', response.body
+
+      wait_to_ensure_asset_pipeline_detects_changes
+
+      FileUtils.cp components_with_updates, components_app_file
+      FileUtils.cp helper_update_file, helper_app_file
+
+      FileUtils.touch components_app_file
+
+      get '/server/1'
+      assert_match 'Injected Header', response.body
+    ensure
+      # if we have a test failure, we want to make sure that we revert the dummy file
+      wait_to_ensure_asset_pipeline_detects_changes
+
+      FileUtils.mv components_without_updates, components_app_file
+      FileUtils.touch components_app_file
+
+      FileUtils.rm helper_app_file
+    end
+  end
 end


### PR DESCRIPTION
Use a custom watcher/reloader middleware to find all the dependent
files of component_filenames and watch them for changes.

The reloader sits outside of the Rails stack, but makes use of
ActiveSupport::FileUpdateChecker.

This has a few benefits:

1. Non-jsx files can easily be watched. For example, changes to
   components.js and other helper files are detected.

2. Newly required files can be detected and added to the list of
   watched files for future updates.

3. We don’t force Rails to reload its own Ruby classes when only .js
   or .jsx files have changed.

One potentially controversial change, which didn’t seem to provide
much benefit before:

- Moved the concatenated source files for components.js and react.js
  out of the app config. They are now encapsulated in the
  after_initialize block.