### PR TITLE
Add support for saving references to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ react_component('HelloMessage', {name: 'John'}, {id: 'hello', class: 'foo', tag:
 # <span class="foo" id="hello" data-...></span>
 ```
 
+If you want to store a global reference to the rendered component, add `reference: 'myReference'` to the options hash:
+
+```ruby
+react_component('HelloMessage', {}, {reference: 'myReference'})
+# <div data-react-class="HelloMessage" data-react-props="{}" data-react-reference="myReference"></div>
+```
+
+`react_ujs` will pick up the `data-react-reference` attribute and store a global reference to the component at the specified name, in this case `myReference`.
+
 #### With JSON and Jbuilder
 
 You can pass prepared JSON directly to the helper, as well.

--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -2,6 +2,7 @@
 (function(document, window, React) {
   var CLASS_NAME_ATTR = 'data-react-class';
   var PROPS_ATTR = 'data-react-props';
+  var REFERENCE_ATTR = 'data-react-reference';
 
   // jQuery is optional. Use it to support legacy browsers.
   var $ = (typeof jQuery !== 'undefined') && jQuery;
@@ -25,7 +26,12 @@
       var constructor = window[className] || eval.call(window, className);
       var propsJson = node.getAttribute(PROPS_ATTR);
       var props = propsJson && JSON.parse(propsJson);
-      React.renderComponent(constructor(props), node);
+      var reference = node.getAttribute(REFERENCE_ATTR);
+      if (reference) {
+        window[reference] = React.renderComponent(constructor(props), node);
+      } else {
+        React.renderComponent(constructor(props), node);
+      }
     }
   };
 

--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -14,11 +14,12 @@ module React
         html_options[:data].tap do |data|
           data[:react_class] = name
           data[:react_props] = React::Renderer.react_props(args) unless args.empty?
+          data[:react_reference] = html_options[:reference] if html_options[:reference]
         end
         html_tag = html_options[:tag] || :div
         
         # remove internally used properties so they aren't rendered to DOM
-        [:tag, :prerender].each{|prop| html_options.delete(prop)}
+        [:tag, :prerender, :reference].each{|prop| html_options.delete(prop)}
         
         content_tag(html_tag, '', html_options, &block)
       end

--- a/test/dummy/app/views/pages/show.html.erb
+++ b/test/dummy/app/views/pages/show.html.erb
@@ -2,4 +2,4 @@
   <li><%= link_to 'Alice', page_path(:id => 0) %></li>
   <li><%= link_to 'Bob', page_path(:id => 1) %></li>
 </ul>
-<%= react_component 'HelloMessage', :name => @name %>
+<%= react_component 'HelloMessage', { :name => @name }, { :reference => 'myReference' } %>

--- a/test/view_helper_test.rb
+++ b/test/view_helper_test.rb
@@ -49,6 +49,16 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
     assert html.include?('data-foo="1"')
   end
 
+  test 'react_component accepts reference option' do
+    assert @helper.react_component('Foo', {}, { reference: 'myReference' })
+      .include?('data-react-reference="myReference"')
+  end
+
+  test 'react_ujs saves reference to rendered component as a global variable' do
+    visit '/pages/1'
+    assert page.evaluate_script('!!window.myReference')
+  end
+
   test 'react_ujs works with rendered HTML' do
     visit '/pages/1'
     assert page.has_content?('Hello Bob')


### PR DESCRIPTION
When rendering a component using the react_component view helper,
pass `reference: 'myReferenceName'` in the options hash to make
react_ujs store a reference to the rendered component at
`window.myReferenceName`. This is useful for scripts that need to
make use of a component after a page has loaded, without needing
to re-render an extra time.