### PR TITLE
Add a configuration option for enabling the JSX Harmony compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,16 @@ MyApp::Application.configure do
 end
 
 ```
+### Compile options
+
+To enable the "Harmony" compile functionality of the JSX compiler (which turns on JS transformations such as ES6 classes, etc.):
+
+```ruby
+MyApp::Application.configure do
+  config.react.harmony = true
+end
+```
+
 
 ## CoffeeScript
 

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -5,6 +5,7 @@ require 'rails'
 
 module React
   module JSX
+
     def self.context
       # lazily loaded during first request and reloaded every time when in dev or test
       unless @context && ::Rails.env.production?
@@ -24,7 +25,8 @@ module React
     end
 
     def self.transform(code)
-      result = context.call('JSXTransformer.transform', code)
+      result = context.call('JSXTransformer.transform', code,
+                            harmony: ::Rails.application.config.react.harmony)
       return result['code']
     end
   end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -13,6 +13,7 @@ module React
       config.react.timeout = 20 #seconds
       config.react.react_js = lambda {File.read(::Rails.application.assets.resolve('react.js'))}
       config.react.component_filenames = ['components.js']
+      config.react.harmony = false    # default to harmony compilation disabled
 
       # Watch .jsx files for changes in dev, so we can reload the JS VMs with the new JS code.
       initializer "react_rails.add_watchable_files" do |app|

--- a/test/dummy/app/assets/javascripts/example4.js.jsx
+++ b/test/dummy/app/assets/javascripts/example4.js.jsx
@@ -1,0 +1,3 @@
+/** @jsx React.DOM */
+class Example4{}
+var e=new Example4();

--- a/test/jsxtransform_test.rb
+++ b/test/jsxtransform_test.rb
@@ -23,6 +23,14 @@ EXPECTED_JS_2 = <<eos
 }).call(this);
 eos
 
+EXPECTED_JS_4 = <<eos
+/** @jsx React.DOM */
+
+function Example4(){"use strict";}
+var e=new Example4();
+eos
+
+
 class JSXTransformTest < ActionDispatch::IntegrationTest
 
   test 'asset pipeline should transform JSX' do
@@ -43,6 +51,18 @@ class JSXTransformTest < ActionDispatch::IntegrationTest
     # together. Remove all spaces to make test pass.
     assert_equal EXPECTED_JS_2.gsub(/\s/, ''), @response.body.gsub(/\s/, '')
   end
+
+  test 'asset pipeline should transform JSX + Harmony' do
+    # multiple tests run simultaneously, so, the setting can't be flipped on
+    # and off for multiple tests (as they'll conflict)
+    Rails.application.config.react.harmony = true
+    get 'assets/example4.js'
+    assert_response :success
+    # remove any unnecessary trailing space from either example or response
+    # as it's not relevant to the test
+    assert_equal EXPECTED_JS_4.rstrip, @response.body.rstrip
+  end
+
 
   test 'can use dropped in version of JSX transformer' do
     hidden_path = File.expand_path("../dummy/vendor/assets/react/JSXTransformer__.js",  __FILE__)


### PR DESCRIPTION
I wanted a way to use the Harmony command line switch automatically from Rails. I've added it as a simple option:

```
MyApp::Application.configure do
  config.react.harmony = true
end
```

I also included a simple test case. 
