### PR TITLE
Remove unused `max_renderers` option from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,7 @@ For performance and thread-safety reasons, a pool of JS VMs are spun up on appli
 # config/environments/application.rb
 # These are the defaults if you dont specify any yourself
 MyApp::Application.configure do
-  config.react.max_renderers = 10
-  config.react.timeout = 20 #seconds
+  config.react.timeout = 20 # seconds
   config.react.react_js = lambda {File.read(::Rails.application.assets.resolve('react.js'))}
   config.react.component_filenames = ['components.js']
 end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -9,8 +9,7 @@ module React
       config.react.variant = (::Rails.env.production? ? :production : :development)
       config.react.addons = false
       # Server-side rendering
-      config.react.max_renderers = 10
-      config.react.timeout = 20 #seconds
+      config.react.timeout = 20 # seconds
       config.react.react_js = lambda {File.read(::Rails.application.assets.resolve('react.js'))}
       config.react.component_filenames = ['components.js']
 


### PR DESCRIPTION
I haven't found the usage of `max_renderers` config option in the code, so I think it's better to remove it, because I thought there are some limit of the renderers possible to use on the page.
