### PR TITLE
Saving react source to Dir.tmpdir

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -37,7 +37,7 @@ module React
         # Copy over the variant into a path that sprockets will pick up.
         # We'll always copy to 'react.js' so that no includes need to change.
         # We'll also always copy of JSXTransformer.js
-        tmp_path = app.root.join('tmp/react-rails')
+        tmp_path = Pathname.new(Dir.tmpdir).join('react-rails')
         filename = 'react' +
                    (app.config.react.addons ? '-with-addons' : '') +
                    (app.config.react.variant == :production ? '.min.js' : '.js')

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 class ReactTest < ActionDispatch::IntegrationTest
 
   test 'asset pipeline should deliver react file in a non-production variant' do
-    actual_react_file_path = File.expand_path("../dummy/tmp/react-rails/react.js",  __FILE__)
+    actual_react_file_path = File.join(Dir.tmpdir, 'react-rails', 'react.js')
     actual_react_file_content = File.read actual_react_file_path
 
     react_file_token = "'test_confirmation_token_react_content_non_production';\n";


### PR DESCRIPTION
We needed to make this change because our CI (Tddium/Solano) runs workers in parallel and `tmp/` inside the repo is not safe.  Thoughts about this?  Thanks!