### PR TITLE
Fix tests on rails 4.2

### DIFF
--- a/test/jsxtransform_test.rb
+++ b/test/jsxtransform_test.rb
@@ -22,14 +22,14 @@ eos
 class JSXTransformTest < ActionDispatch::IntegrationTest
 
   test 'asset pipeline should transform JSX' do
-    get 'assets/example.js'
+    get '/assets/example.js'
     FileUtils.rm_r CACHE_PATH if CACHE_PATH.exist?
     assert_response :success
     assert_equal EXPECTED_JS, @response.body
   end
 
   test 'asset pipeline should transform JSX + Coffeescript' do
-    get 'assets/example2.js'
+    get '/assets/example2.js'
     assert_response :success
     # Different coffee-script may generate slightly different outputs,
     # as some version inserts an extra "\n" at the beginning.
@@ -43,7 +43,7 @@ class JSXTransformTest < ActionDispatch::IntegrationTest
     replacing_path = File.expand_path("../dummy/vendor/assets/react/JSXTransformer.js",  __FILE__)
 
     FileUtils.mv hidden_path, replacing_path
-    get 'assets/example3.js'
+    get '/assets/example3.js'
 
     FileUtils.mv replacing_path, hidden_path
     FileUtils.rm_r CACHE_PATH if CACHE_PATH.exist?

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -10,7 +10,7 @@ class ReactTest < ActionDispatch::IntegrationTest
     react_file_token = "'test_confirmation_token_react_content_non_production';\n";
     File.open(actual_react_file_path, 'w') {|f| f.write react_file_token}
 
-    get 'assets/react.js'
+    get '/assets/react.js'
 
     File.open(actual_react_file_path, 'w') {|f| f.write actual_react_file_content}
     FileUtils.rm_r CACHE_PATH if CACHE_PATH.exist?
@@ -24,7 +24,7 @@ class ReactTest < ActionDispatch::IntegrationTest
     replacing_path = File.expand_path("../dummy/vendor/assets/react/test/react.js",  __FILE__)
 
     FileUtils.mv hidden_path, replacing_path
-    get 'assets/react.js'
+    get '/assets/react.js'
 
     FileUtils.mv replacing_path, hidden_path
     FileUtils.rm_r CACHE_PATH if CACHE_PATH.exist?


### PR DESCRIPTION
From http://edgeguides.rubyonrails.org/4_2_release_notes.html#action-pack

> When calling the process helpers in an integration test the path needs to have a leading slash.
> Previously you could omit it but that was a byproduct of the implementation and
> not an intentional feature.
- Fixed all get requests to have a forward slash to fix failing tests on rails 4.2
