### PR TITLE
Upgrade react-source to 0.12.2

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'execjs'
   s.add_dependency 'rails', '>= 3.1'
-  s.add_dependency 'react-source', '0.12'
+  s.add_dependency 'react-source', '~> 0.12'
   s.add_dependency 'connection_pool'
 
   s.files = Dir[

--- a/test/jsxtransform_test.rb
+++ b/test/jsxtransform_test.rb
@@ -10,7 +10,7 @@ EXPECTED_JS_2 = <<eos
 (function() {
   var Component;
 
-  Component = React.createClass({displayName: 'Component',
+  Component = React.createClass({displayName: "Component",
     render: function() {
       return React.createElement(ExampleComponent, {videos:this.props.videos} );
     }


### PR DESCRIPTION
Upgrading react-source to 0.12.2

Tests were failing when expecting a single quoted string in transformed JSX. It looks like this can be traced back to facebook/react@eddbb0c, so I'm updating the expectation to a double-quoted string—see 71a01bc.