### PR TITLE
Cache bundler installs on TravisCI for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 2.2
   - 2.1


### PR DESCRIPTION
Also removes explicit install of bundler. Travis has it already.