### PR TITLE
Report test coverage to codeclimate

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'es5-shim-rails', '>= 2.0.5'
   s.add_development_dependency 'poltergeist', '>= 0.3.3'
   s.add_development_dependency 'test-unit', '~> 2.5'
+  s.add_development_dependency 'codeclimate-test-reporter'
 
   s.add_development_dependency 'jbuilder'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 


### PR DESCRIPTION
I'm really not sure about where this gem dependency should be specified. I remember being confused by this for dev dependencies in the past and just shoved everything in the gemspec. But I just listened to what Code Climate told me to do to set this up. Correct me if I'm wrong. cc @rmosolgo