### PR TITLE
Use isolate_namespace in Engine, to play nice with other Engines.

### DIFF
--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -1,6 +1,8 @@
 module React
   module Rails
     class Engine < ::Rails::Engine
+      isolate_namespace React
+
       initializer "react_rails.setup_engine", :group => :all do |app|
         app.assets.register_engine '.jsx', React::JSX::Template
       end


### PR DESCRIPTION
I have an app where [this exception](https://github.com/rails/rails/blob/375d9a0a7fb329b0fbbd75a13e93e53a00520587/activesupport/lib/active_support/dependencies.rb#L444-L446) in `ActiveSupport::Dependencies` is getting raised (regarding another Engine's helpers) whenever there is a change to any JavaScript file.

This error only emerged after adding `react-rails`. Testing against my branch with the inclusion of `isolate_namespace React`, the exception no longer gets raised.

Including `isolate_namespace` is [highly recommended in the Rails Guides](http://guides.rubyonrails.org/engines.html#critical-files). I'm curious if there is a reason why it is not present?