### PR TITLE
Correctly pass `max_renderers` config to setup

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -74,7 +74,7 @@ module React
         do_setup = lambda do
           cfg = app.config.react
           React::Renderer.setup!( cfg.react_js, cfg.components_js,
-                                {:size => cfg.size, :timeout => cfg.timeout})
+                                {:size => cfg.max_renderers, :timeout => cfg.timeout})
         end
 
         do_setup.call


### PR DESCRIPTION
This has been broken for a while :grimacing: 

Basically, the code has been passing the wrong variable in, so the render pool size was always defaulting to `10`.