### PR TITLE
feat(ujs) Pass contents of content tag to React component.

### DIFF
--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -7,6 +7,7 @@ module React
       # on the client.
       #
       def react_component(name, args = {}, options = {}, &block)
+        args[:__html] = capture(&block) if block.present? && options[:__html]
         options = {:tag => options} if options.is_a?(Symbol)
         block = Proc.new{concat React::Renderer.render(name, args)} if options[:prerender]
 
@@ -16,13 +17,12 @@ module React
           data[:react_props] = React::Renderer.react_props(args) unless args.empty?
         end
         html_tag = html_options[:tag] || :div
-        
+
         # remove internally used properties so they aren't rendered to DOM
         html_options.except!(:tag, :prerender)
-        
+
         content_tag(html_tag, '', html_options, &block)
       end
-
     end
   end
 end


### PR DESCRIPTION
### Usage

```erb
<%= react_component('FilterChildren') do %>
  <div>Some child HTML that you want to use in your component</div>
  <div>Even though we'll likely be using React's dangerouslySetInnerHTML property, it's better than writing jQuery and tracking down the magic classes and markup</div>
<% end %>
```

```jsx
var FilterChildren = React.createClass({
  propTypes: {
    __html: React.PropTypes.string
  },

  someTransformationOfRawHTML: function() {
    /* do something with this.props.__html */
  }, 

  render: function() {
    return <div dangerouslySetInnerHTML={{__html: this.someTransformationOfRawHTML()}} />;
  }
});
```

In your component, `this.props.__html` will be available. The value is the string `domNode.innerHTML`, where `domNode` is the node being mounted on.