### PR TITLE
chore(gems) use coffee-script-source 1.8.0

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'jbuilder'
 
   s.add_dependency 'execjs'
+  s.add_dependency 'coffee-script-source', '1.8.0'
   s.add_dependency 'rails', '>= 3.1'
   s.add_dependency 'react-source', '0.12'
   s.add_dependency 'connection_pool'


### PR DESCRIPTION
Looks like some bug in `coffee-script-source 1.9.0` 

https://github.com/jashkenas/coffeescript/issues/3829

curious if this will do the trick