### PR TITLE
fix(gems) add coffeescript 1.9.1

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'jbuilder'
 
   s.add_dependency 'execjs'
-  s.add_dependency 'coffee-script-source', '1.8.0'
+  s.add_dependency 'coffee-script-source', '~>1.9'
   s.add_dependency 'rails', '>= 3.1'
   s.add_dependency 'react-source', '~> 0.12'
   s.add_dependency 'connection_pool'


### PR DESCRIPTION
They've published coffee-script-source 1.9.1, let's see if that resolves the test failure issue 