### PR TITLE
fix(ujs) always handle native events, _also_ handle turbolinks if appropriate

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -79,6 +79,9 @@
     }
     handleEvent('page:change', window.ReactRailsUJS.mountComponents);
     handleEvent(unmountEvent, window.ReactRailsUJS.unmountComponents);
+    // you can get a native page-change a couple ways, eg after deploying new assets, clicking data-no-turbolink
+    window.addEventListener('unload', window.ReactRailsUJS.unmountComponents);
+
   }
 
   function handleNativeEvents() {


### PR DESCRIPTION
As mentioned in #108 , sometimes a turbolinks app still has native events. So, 

- always handle native events 
- also support turbolinks events 

Since the UJS functions are public now, we could put turbolinks UJS in its own file, right? Using turbolinks would be:

```js
//= require react_ujs
//= require react_turbolinks_ujs // or something
```

That's a backwards incompatibility though, maybe we should wait a bit