### PR TITLE
fix(ujs) don't remove nodes after unmounting components

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -47,8 +47,6 @@
         var node = nodes[i];
 
         React.unmountComponentAtNode(node);
-        // now remove the `data-react-class` wrapper as well
-        node.parentElement && node.parentElement.removeChild(node);
       }
     }
   };


### PR DESCRIPTION
Don't remove wrappers after unmounting nodes because it breaks Turbolinks cache (#159). 

I can't find the PR where this was added, I would like to go back and see why, but now I can't find it :( 

Anyways, I was surprised this broke because I remember we have a test for navigating back and forth and making sure things mount ok. I added a test and found that in fact, Turbolinks isn't supported in the test environment: 

```  ruby
test 'turbolinks works in test'  do
  assert(page.evaluate_script('Turbolinks.supported')) # fails
end
```

So, the test doesn't guarantee turbolinks works :(