### PR TITLE
Replay console logging on client after server prerender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.lock
 *.log
 test/dummy/tmp
 gemfiles/*.lock
+*.swp

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ end
 
 ### Server Rendering
 
-For performance and thread-safety reasons, a pool of JS VMs are spun up on application start, and the size of the pool and the timeout on requesting a VM from the pool are configurable. You can also say where you want to grab the `react.js` code from, and if you want to change the filenames for the components (this should be an array of filenames that will be requested from the asset pipeline and concatenated together.)
+For performance and thread-safety reasons, a pool of JS VMs are spun up on application start, and the size of the pool and the timeout on requesting a VM from the pool are configurable.
 
 ```ruby
 # config/environments/application.rb
@@ -316,9 +316,14 @@ MyApp::Application.configure do
   config.react.timeout = 20 #seconds
   config.react.react_js = lambda {File.read(::Rails.application.assets.resolve('react.js'))}
   config.react.component_filenames = ['components.js']
+  config.react.replay_console = false
 end
-
 ```
+
+Other configuration options include:
+* `react_js`: where you want to grab the javascript library from
+* `component_filenames`: an array of filenames that will be requested from the asset pipeline and concatenated together
+* `replay_console`: additional debugging by replaying any captured console messages from server-rendering back on the client (note: they will lose their call stack, but it can help point you in right direction)
 
 ## CoffeeScript
 

--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -47,8 +47,6 @@
         var node = nodes[i];
 
         React.unmountComponentAtNode(node);
-        // now remove the `data-react-class` wrapper as well
-        node.parentElement && node.parentElement.removeChild(node);
       }
     }
   };

--- a/lib/react-rails.rb
+++ b/lib/react-rails.rb
@@ -1,4 +1,5 @@
 require 'react/jsx'
 require 'react/renderer'
 require 'react/rails'
+require 'react/console'
 

--- a/lib/react/console.rb
+++ b/lib/react/console.rb
@@ -1,0 +1,30 @@
+module React
+  class Console
+    def self.polyfill_js
+      # Overwrite global `console` object with something that can capture messages
+      # to return to client later for debugging
+      <<-JS
+      var console = { history: [] };
+      ['error', 'log', 'info', 'warn'].forEach(function (fn) {
+        console[fn] = function () {
+          console.history.push({level: fn, arguments: Array.prototype.slice.call(arguments)});
+        };
+      });
+      JS
+    end
+
+    def self.replay_as_script_js
+      <<-JS
+      (function (history) {
+        if (history && history.length > 0) {
+          result += '\\n<scr'+'ipt>';
+          history.forEach(function (msg) {
+            result += '\\nconsole.' + msg.level + '.apply(console, ' + JSON.stringify(msg.arguments) + ');';
+          });
+          result += '\\n</scr'+'ipt>';
+        }
+      })(console.history);
+      JS
+    end
+  end
+end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -71,7 +71,7 @@ module React
 
         do_setup = lambda do
           cfg = app.config.react
-          React::Renderer.setup!( cfg.react_js, cfg.components_js,
+          React::Renderer.setup!( cfg.react_js, cfg.components_js, cfg.replay_console,
                                 {:size => cfg.max_renderers, :timeout => cfg.timeout})
         end
 

--- a/test/dummy/app/assets/javascripts/components/TodoListWithConsoleLog.js.jsx
+++ b/test/dummy/app/assets/javascripts/components/TodoListWithConsoleLog.js.jsx
@@ -1,0 +1,23 @@
+TodoListWithConsoleLog = React.createClass({
+  getInitialState: function() {
+    console.log('got initial state');
+    return({mounted: "nope"});
+  },
+  componentWillMount: function() {
+    console.warn('mounted component');
+    this.setState({mounted: 'yep'});
+  },
+  render: function() {
+    var x = 'foo';
+    console.error('rendered!', x);
+    return (
+      <ul>
+        <li>Console Logged</li>
+        <li id='status'>{this.state.mounted}</li>
+        {this.props.todos.map(function(todo, i) {
+          return (<Todo key={i} todo={todo} />)
+        })}
+      </ul>
+    )
+  }
+})

--- a/test/dummy/app/assets/javascripts/example2.js.jsx.coffee
+++ b/test/dummy/app/assets/javascripts/example2.js.jsx.coffee
@@ -1,3 +1,5 @@
 Component = React.createClass
   render: ->
     `<ExampleComponent videos={this.props.videos} />`
+
+window.Component = Component

--- a/test/dummy/app/controllers/server_controller.rb
+++ b/test/dummy/app/controllers/server_controller.rb
@@ -2,4 +2,23 @@ class ServerController < ApplicationController
   def show
     @todos = %w{todo1 todo2 todo3}
   end
+
+  def console_example
+    hack_replay_console_config true
+    @todos = %w{todo1 todo2 todo3}
+  end
+
+  def console_example_suppressed
+    hack_replay_console_config false
+    @todos = %w{todo1 todo2 todo3}
+  end
+
+  private
+  def hack_replay_console_config(value)
+    # Don't do this in your app; just set it how you want it in config/application.rb
+    cfg = ::Rails.application.config.react
+    cfg.replay_console = value
+    React::Renderer.setup!( cfg.react_js, cfg.components_js, cfg.replay_console,
+                        {:size => cfg.max_renderers, :timeout => cfg.timeout})
+  end
 end

--- a/test/dummy/app/views/server/console_example.html.erb
+++ b/test/dummy/app/views/server/console_example.html.erb
@@ -1,0 +1,1 @@
+<%= react_component "TodoListWithConsoleLog", {todos: @todos}, {prerender: true} %>

--- a/test/dummy/app/views/server/console_example_suppressed.html.erb
+++ b/test/dummy/app/views/server/console_example_suppressed.html.erb
@@ -1,0 +1,1 @@
+<%= react_component "TodoListWithConsoleLog", {todos: @todos}, {prerender: true} %>

--- a/test/dummy/app/views/server/show.html.erb
+++ b/test/dummy/app/views/server/show.html.erb
@@ -1,1 +1,1 @@
-<%= react_component "TodoList", {:todos => @todos}, :prerender => true %>
+<%= react_component "TodoList", {todos: @todos}, {prerender: true} %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,9 @@
 Dummy::Application.routes.draw do
-  resources :pages, :only => [:show]
-  resources :server, :only => [:show]
+  resources :pages, only: [:show]
+  resources :server, only: [:show] do
+    collection do
+      get :console_example
+      get :console_example_suppressed
+    end
+  end
 end

--- a/test/jsxtransform_test.rb
+++ b/test/jsxtransform_test.rb
@@ -16,6 +16,7 @@ EXPECTED_JS_2 = <<eos
     }
   });
 
+  window.Component = Component;
 }).call(this);
 eos
 


### PR DESCRIPTION
Addresses reactjs/react-rails#122.  Adds a new `replay_console: true` option, to be used in conjunction with `prerender: true` on the `react_component` view helper (can assist in debugging).  Updated README and added integration tests.