### PR TITLE
adding semi-colon in front of IIFE

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -1,7 +1,7 @@
 /*globals React, Turbolinks*/
 
 // Unobtrusive scripting adapter for React
-(function(document, window) {
+;(function(document, window) {
   // jQuery is optional. Use it to support legacy browsers.
   var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
 


### PR DESCRIPTION
# Description

This PR address an edge case when there's bad written JavaScript before requiring `react_ujs`. Given how automatic semi-colon insertion works in JavaScript, an IIFE can be evaluated as a function call instead of a evaluation context.

This happened to me using `browserify-rails` and requiring `react_ujs` just after doing `require('React')`, but it can happen in multiple scenarios.

## Tasks

* [x] Add semi-colon before IIFE in **react_ujs.js.erb** file

## Screenshots

![screen shot 2015-03-14 at 10 59 05 am](https://cloud.githubusercontent.com/assets/849872/6652580/e80e7820-ca38-11e4-9030-24bdd2bce30d.png)
