### PR TITLE
Fix for Issue #212 components.js generated by assets:precompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,20 @@ MyApp::Application.configure do
   config.react.react_js = lambda {File.read(::Rails.application.assets.resolve('react.js'))}
   config.react.component_filenames = ['components.js']
 end
-
 ```
+
+#### Precompiled Component File
+
+The default configuration assumes the asset pipeline is available in all environments.  If you precompile assets for production and want to fetch `components.js` from the precompiled assets, add this additional configuration:
+
+```ruby
+config.react.component_js = lambda do
+  config.react.component_filenames.map do |filename|
+    File.read(Rails.root.join('public', 'assets', filename))
+  end.join(';')
+end
+```
+
 
 ## CoffeeScript
 

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -65,7 +65,7 @@ module React
       config.after_initialize do |app|
         # Server Rendering
         # Concat component_filenames together for server rendering
-        app.config.react.components_js = lambda {
+        app.config.react.components_js ||= lambda {
           app.config.react.component_filenames.map do |filename|
             app.assets[filename].to_s
           end.join(";")


### PR DESCRIPTION
is not used.

- allow user to override the components_js lamdba