### PR TITLE
Point Gemfile instructions at GitHub master instead of nonexistent prerelease version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Add `react-rails` to your gemfile:
 ```ruby
 # Gemfile
 # If you missed a warning at the top of this README - this is still in development
-# which means this version is not pushed to rubygems.org
+# which means the latest is not pushed to rubygems.org or tagged as a version. Live
+# on the bleeding edge and depend on master.
 
-gem 'react-rails', '~> 1.0.0.pre', github: 'reactjs/react-rails'
+gem 'react-rails', github: 'reactjs/react-rails'
 ```
 
 Next, run the installation script.


### PR DESCRIPTION
It's totally cool to encourage people to use master, but attaching a "pre" version number is pretty confusing, as it implies that there is a branch, tag, or published gem somewhere.

This hopefully removes that confusion and just implies that you're pulling from master.