### PR TITLE
Lower the coffee-script-source version specifier

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'jbuilder'
 
   s.add_dependency 'execjs'
-  s.add_dependency 'coffee-script-source', '~>1.9'
+  s.add_dependency 'coffee-script-source', '~>1.8'
   s.add_dependency 'rails', '>= 3.1'
   s.add_dependency 'react-source', '~> 0.12'
   s.add_dependency 'connection_pool'


### PR DESCRIPTION
Much apologies if this has already been addressed. I’ve seen a few similar issues (https://github.com/reactjs/react-rails/pull/167#issuecomment-73306684, https://github.com/reactjs/react-rails/pull/168), but no apparent resolution. 

There seems to be a known issue with the latest version of `coffee-script-source` outlined in https://github.com/jashkenas/coffeescript/issues/382.

The `react-rails` gemspec specifies a `~>1.9` version of `coffee-script-source`, which makes it impossible to back out of its most recent version, in order to avoid the errors (for example, if you want to specify `~>1.8` in your app). 

This change lowers the dependency version in the `react-rails` gemspec so that a user can specify a lower working version.