### PR TITLE
feat(versions) add VERSIONS.md for gem/React versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ end
 
 After restarting your Rails server, `//= require react`  will provide the build of React.js which was specified by the configurations.
 
-In a pinch, you can also provide your own copies of React.js and JSXTransformer. Just add `react.js` or `JSXTransformer.js` (case-sensitive) files to `app/vendor/assets/javascripts/react/` and restart your development server. If you need different versions of React in different environments, put them in directories that match `config.react.variant`. For example, if you set `config.react.variant = :development`, you could put a copy of `react.js` in `/vendor/assets/react/development/`.
+`react-rails` offers a few other options for versions & builds of React.js. See [VERSIONS.md](https://github.com/reactjs/react-rails/blob/master/VERSIONS.md) for more info about using the `react-source` gem or dropping in your own copies of React.js.
 
 ### JSX
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,43 @@
+# Versions
+
+There are three ways to control what version of React.js (and JSXTransformer) is used by `react-rails`:
+
+- Use the [bundled version](#bundled-versions) that comes with the gem
+- Specify a [react-source verison](#react-source-version)
+- [Drop in a copy](#drop-in-version) of React.js
+
+## Bundled Versions
+
+| Gem      | React.js |
+|----------|----------|
+| master   | ~> 0.13  |
+| 0.13.0.0 | 0.13.0   |
+| 0.12.2.0 | 0.12.2   |
+| 0.12.1.0 | 0.12.1   |
+| 0.12.0.0 | 0.12.0   |
+
+
+## React-Source Version
+
+The [`react-source` gem](https://rubygems.org/gems/react-source) provides JS files to `react-rails`.
+
+You can specify a React.js version by locking to a specific `react-source` in your Gemfile. For example:
+
+```ruby
+gem 'react-rails'
+# always use React version 0.13.1:
+gem 'react-source', '0.13.1'
+```
+
+## Drop-in Version
+
+You can also provide your own copies of React.js and JSXTransformer. Just add `react.js` or `JSXTransformer.js` (case-sensitive) files in directories where `react-rails` expects to find them.
+
+To use the _same version in all environments_, put files in `app/vendor/assets/react/`.
+
+If you need _different versions in different environments_, put them in directories that match `config.react.variant`. For example, if you set `config.react.variant = :development`, you could put a copy of `react.js` in `app/vendor/assets/react/development/`.
+
+
+
+
+

--- a/lib/react/rails/version.rb
+++ b/lib/react/rails/version.rb
@@ -1,5 +1,6 @@
 module React
   module Rails
+    # If you change this, make sure to update VERSIONS.md
     VERSION = '1.0.0.pre'
   end
 end

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'execjs'
   s.add_dependency 'coffee-script-source', '~>1.8'
   s.add_dependency 'rails', '>= 3.1'
+  # If you change this, make sure to update VERSIONS.md:
   s.add_dependency 'react-source', '~> 0.13'
   s.add_dependency 'connection_pool'
 


### PR DESCRIPTION
As expressed in #133, we need a way to better express how gem versions and react versions compare. 

I've taken a page from [jquery-rails](https://github.com/rails/jquery-rails)'s book and added a `VERSIONS.md` file with info about bundled versions. I also put information there about other ways of controlling the React version.

Right now, the update plan is pretty low-tech: I added comments to gem version and `react-source` version to remind anyone to update `VERSIONS.md`. In my opinion, this is better than what we have now and good enough for the time being. 

If you prefer, we could add a rake task for updating the react version. I think it's overkill (more maintenance overhead than the comments, more likely to break in the future), but jquery-rails does something similar and I'm open to it.