### PR TITLE
refactor(Railtie) move react path calculation to separate class

### DIFF
--- a/lib/react/rails.rb
+++ b/lib/react/rails.rb
@@ -1,3 +1,4 @@
-require 'react/rails/railtie'
+require 'react/rails/asset_registry'
 require 'react/rails/engine'
+require 'react/rails/railtie'
 require 'react/rails/view_helper'

--- a/lib/react/rails/asset_registry.rb
+++ b/lib/react/rails/asset_registry.rb
@@ -1,0 +1,25 @@
+module React
+  module Rails
+    # Map to files provided by React::Source,
+    # based on Rails application config.
+    class AssetRegistry
+      attr_reader :config
+      def initialize(config:)
+        @config = config
+      end
+
+      # Determine the React build based on Rails configs
+      def react_source
+        filename = 'react' +
+          (config.react.addons ? '-with-addons' : '') +
+          (config.react.variant == :production ? '.min.js' : '.js')
+        React::Source.bundled_path_for(filename)
+      end
+
+      # JSXTransformer is always the same
+      def jsx_transformer_source
+        React::Source.bundled_path_for('JSXTransformer.js')
+      end
+    end
+  end
+end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -42,9 +42,9 @@ module React
         FileUtils.mkdir_p(tmp_path)
         app.assets.prepend_path tmp_path
 
-        asset_clone = React::Rails::AssetRegistry.new(config: app.config)
-        FileUtils.cp(asset_clone.react_source, tmp_path.join('react.js'))
-        FileUtils.cp(asset_clone.jsx_transformer_source,tmp_path.join('JSXTransformer.js'))
+        asset_registry = React::Rails::AssetRegistry.new(config: app.config)
+        FileUtils.cp(asset_registry.react_source,           tmp_path.join('react.js'))
+        FileUtils.cp(asset_registry.jsx_transformer_source, tmp_path.join('JSXTransformer.js'))
 
         # Allow overriding react files that are not based on environment
         # e.g. /vendor/assets/react/JSXTransformer.js

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -37,16 +37,14 @@ module React
         # Copy over the variant into a path that sprockets will pick up.
         # We'll always copy to 'react.js' so that no includes need to change.
         # We'll also always copy of JSXTransformer.js
+
         tmp_path = app.root.join('tmp/react-rails')
-        filename = 'react' +
-                   (app.config.react.addons ? '-with-addons' : '') +
-                   (app.config.react.variant == :production ? '.min.js' : '.js')
         FileUtils.mkdir_p(tmp_path)
-        FileUtils.cp(::React::Source.bundled_path_for(filename),
-                     tmp_path.join('react.js'))
-        FileUtils.cp(::React::Source.bundled_path_for('JSXTransformer.js'),
-                     tmp_path.join('JSXTransformer.js'))
         app.assets.prepend_path tmp_path
+
+        asset_clone = React::Rails::AssetRegistry.new(config: app.config)
+        FileUtils.cp(asset_clone.react_source, tmp_path.join('react.js'))
+        FileUtils.cp(asset_clone.jsx_transformer_source,tmp_path.join('JSXTransformer.js'))
 
         # Allow overriding react files that are not based on environment
         # e.g. /vendor/assets/react/JSXTransformer.js


### PR DESCRIPTION
`railtie.rb` has been growing bit-by-bit, I think we could clear it up a bit by moving this logic into another object.