### PR TITLE
Add jsx_transformer_js option

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ MyApp::Application.configure do
   config.react.timeout = 20
   # where to get React.js source:
   config.react.react_js = lambda { File.read(::Rails.application.assets.resolve('react.js')) }
+  # where to get JSXTransformer.js
+  config.react.jsx_transformer_js = lambda { File.read(::Rails.application.assets.resolve('JSXTransformer.js')) }
   # array of filenames that will be requested from the asset pipeline
   # and concatenated:
   config.react.component_filenames = ['components.js']

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -5,7 +5,7 @@ require 'rails'
 
 module React
   module JSX
-    mattr_accessor :transform_options
+    mattr_accessor :transform_options, :jsx_transformer_js
 
     def self.context
       # lazily loaded during first request and reloaded every time when in dev or test
@@ -17,7 +17,7 @@ module React
 
           # search for transformer file using sprockets - allows user to override
           # this file in his own application
-          File.read(::Rails.application.assets.resolve('JSXTransformer.js'))
+          jsx_transformer_js.call
 
         @context = ExecJS.compile(contents)
       end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -13,6 +13,7 @@ module React
       config.react.max_renderers = 10
       config.react.timeout = 20 #seconds
       config.react.react_js = lambda {File.read(::Rails.application.assets.resolve('react.js'))}
+      config.react.jsx_transformer_js = lambda {File.read(::Rails.application.assets.resolve('JSXTransformer.js'))}
       config.react.component_filenames = ['components.js']
 
       # Watch .jsx files for changes in dev, so we can reload the JS VMs with the new JS code.
@@ -71,6 +72,7 @@ module React
 
         do_setup = lambda do
           cfg = app.config.react
+          React::JSX.jsx_transformer_js = cfg.jsx_transformer_js
           React::Renderer.setup!( cfg.react_js, cfg.components_js, cfg.replay_console,
                                 {:size => cfg.max_renderers, :timeout => cfg.timeout})
         end


### PR DESCRIPTION
It forces the path to JSXTransformer.js.

Currently `assets.resolve("JSXTransformer.js")` seems to search in `tmp/react-rails`, `vendor/assets/react` and `vendor/assets/react/development` at first.

So it's hard to place custom version in other directories like `vendor/assets/bower_components` managed with bower.