### PR TITLE
Sprockets 3.0 support

### DIFF
--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -1,8 +1,8 @@
 module React
   module Rails
     class Engine < ::Rails::Engine
-      config.after_initialize do |app|
-        app.assets.register_engine '.jsx', React::JSX::Template
+      initializer "react_rails.setup_engine", group: :all do |app|
+        Sprockets.register_engine '.jsx', React::JSX::Template
       end
     end
   end

--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -1,7 +1,7 @@
 module React
   module Rails
     class Engine < ::Rails::Engine
-      initializer "react_rails.setup_engine", :group => :all do |app|
+      config.after_initialize do |app|
         app.assets.register_engine '.jsx', React::JSX::Template
       end
     end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -28,7 +28,7 @@ module React
         end
       end
 
-      initializer "react_rails.setup_vendor", group: :all do |app|
+      config.after_initialize do |app|
         # Mimic behavior of ember-rails...
         # We want to include different files in dev/prod. The unminified builds
         # contain console logging for invariants and logging to help catch
@@ -46,6 +46,7 @@ module React
                      tmp_path.join('react.js'))
         FileUtils.cp(::React::Source.bundled_path_for('JSXTransformer.js'),
                      tmp_path.join('JSXTransformer.js'))
+
         app.assets.prepend_path tmp_path
 
         # Allow overriding react files that are not based on environment
@@ -57,10 +58,7 @@ module React
         # e.g. /vendor/assets/react/development/react.js
         dropin_path_env = app.root.join("vendor/assets/react/#{app.config.react.variant}")
         app.assets.prepend_path dropin_path_env if dropin_path_env.exist?
-      end
 
-
-      config.after_initialize do |app|
         # Server Rendering
         # Concat component_filenames together for server rendering
         app.config.react.components_js = lambda {
@@ -80,8 +78,6 @@ module React
         # Reload the JS VMs in dev when files change
         ActionDispatch::Reloader.to_prepare(&do_setup)
       end
-
-
     end
   end
 end


### PR DESCRIPTION
In Sprockets 3.0 `app.assets` is assigned in `after_initialize` callback (https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb#L142).
So we can use `app.assets` only from `after_initialize` in react-rails.

Solves #240 