### PR TITLE
Rspec tests fail due to `tilt` dependency

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 3.1'
   # If you change this, make sure to update VERSIONS.md:
   s.add_dependency 'react-source', '~> 0.13'
+  s.add_dependency 'tilt'
 
   s.files = Dir[
     'lib/**/*',


### PR DESCRIPTION
This is related to [#243](https://github.com/reactjs/react-rails/pull/243/files)

I am using react-rails as dependency in a gem I created and running rspec in that gem throws the following error:

$ rspec
/Users/gbanis/.rvm/gems/ruby-2.0.0-p598/gems/react-rails-0.13.0.0/lib/react/jsx/template.rb:1:in `require': cannot load such file -- tilt (LoadError)
    from /Users/gbanis/.rvm/gems/ruby-2.0.0-p598/gems/react-rails-0.13.0.0/lib/react/jsx/template.rb:1:in `<top (required)>'
    from /Users/gbanis/.rvm/gems/ruby-2.0.0-p598/gems/react-rails-0.13.0.0/lib/react/jsx.rb:3:in `require'
    from /Users/gbanis/.rvm/gems/ruby-2.0.0-p598/gems/react-rails-0.13.0.0/lib/react/jsx.rb:3:in `<top (required)>'
    from /Users/gbanis/.rvm/gems/ruby-2.0.0-p598/gems/react-rails-0.13.0.0/lib/react-rails.rb:1:in `require'
    from /Users/gbanis/.rvm/gems/ruby-2.0.0-p598/gems/react-rails-0.13.0.0/lib/react-rails.rb:1:in `<top (required)>'
    ...
This happens because react-rails requires tilt here.

I've noticed that adding tilt as a dependency in the gemspec solves this issue and all other tests run without a problem.