### PR TITLE
Change permissions on copied file so subsequent deploys work.

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -42,10 +42,18 @@ module React
                    (app.config.react.addons ? '-with-addons' : '') +
                    (app.config.react.variant == :production ? '.min.js' : '.js')
         FileUtils.mkdir_p(tmp_path)
+
+        # Copy over files and set permissions so subsequent deploys can overwrite files
         FileUtils.cp(::React::Source.bundled_path_for(filename),
-                     tmp_path.join('react.js'))
+                    tmp_path.join('react.js'))
+        FileUtils.chmod("u=rw,g=rw", 
+                    tmp_path.join("react.js")) if File.stat(tmp_path.join("react.js")).owned?
+        
         FileUtils.cp(::React::Source.bundled_path_for('JSXTransformer.js'),
-                     tmp_path.join('JSXTransformer.js'))
+                    tmp_path.join('JSXTransformer.js'))
+        FileUtils.chmod("u=rw,g=rw",
+                    tmp_path.join("JSXTransformer.js")) if File.stat(tmp_path.join("JSXTransformer.js")).owned?
+
         app.assets.prepend_path tmp_path
 
         # Allow overriding react files that are not based on environment


### PR DESCRIPTION
In some production environments, the permissions of the copied file were not being set in a way where subsequent deploys could overwrite the files if necessary. This sets the initial permissions of the two problematic files so that subsequent deploys do not run into this permissions issue.

Fixes #175 