### PR TITLE
Use standard shortcode for Apache-2.0

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary = 'React/JSX adapter for the Ruby on Rails asset pipeline.'
   s.description = 'Compile your JSX on demand or precompile for production.'
   s.homepage = 'https://github.com/reactjs/react-rails'
-  s.license = 'APL 2.0'
+  s.license = 'Apache-2.0'
 
   s.author = ['Paul O’Shannessy']
   s.email = ['paul@oshannessy.com']


### PR DESCRIPTION
Hi!

Just a quick change to make license-finding tools like [license_finder][0] happier based off [industry standards][1].

Thanks!

[0]: https://github.com/pivotal/LicenseFinder
[1]: https://spdx.org/licenses/