### PR TITLE
refactor(JSX::Transformer) use Transformer class; allow asset_path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can use JSX `--harmony` or `--strip-types` options by adding a configuration
 config.react.jsx_transform_options = {
   harmony: true,
   strip_types: true, # for removing Flow type annotations
+  asset_path: "path/to/JSXTransformer.js", # if your JSXTransformer is somewhere else
 }
 ```
 

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -5,7 +5,14 @@ require 'rails'
 
 module React
   module JSX
-    mattr_accessor :transform_options
+    mattr_accessor :transform_options, :transformer_class
+
+    # You can assign `React::JSX.transformer_class = `
+    # to provide your own transformer. It must implement:
+    # - #initialize(options)
+    # - #transform(code) => new code
+    self.transformer_class = Transformer
+
     def self.transform(code)
       transformer.transform(code)
     end
@@ -13,7 +20,7 @@ module React
     def self.transformer
       # lazily loaded during first request and reloaded every time when in dev or test
       if @transformer.nil? || !::Rails.env.production?
-        @transformer = Transformer.new(transform_options)
+        @transformer = transformer_class.new(transform_options)
       end
       @transformer
     end

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -1,36 +1,21 @@
 require 'execjs'
 require 'react/jsx/template'
+require 'react/jsx/transformer'
 require 'rails'
 
 module React
   module JSX
     mattr_accessor :transform_options
-
-    def self.context
-      # lazily loaded during first request and reloaded every time when in dev or test
-      unless @context && ::Rails.env.production?
-        contents =
-          # If execjs uses therubyracer, there is no 'global'. Make sure
-          # we have it so JSX script can work properly.
-          'var global = global || this;' +
-
-          # search for transformer file using sprockets - allows user to override
-          # this file in his own application
-          File.read(::Rails.application.assets.resolve('JSXTransformer.js'))
-
-        @context = ExecJS.compile(contents)
-      end
-
-      @context
+    def self.transform(code)
+      transformer.transform(code)
     end
 
-    def self.transform(code, options={})
-      js_options = {
-        stripTypes: options[:strip_types],
-        harmony: options[:harmony],
-      }
-      result = context.call('JSXTransformer.transform', code, js_options)
-      return result['code']
+    def self.transformer
+      # lazily loaded during first request and reloaded every time when in dev or test
+      if @transformer.nil? || !::Rails.env.production?
+        @transformer = Transformer.new(transform_options)
+      end
+      @transformer
     end
   end
 end

--- a/lib/react/jsx/template.rb
+++ b/lib/react/jsx/template.rb
@@ -10,7 +10,7 @@ module React
       end
 
       def evaluate(scope, locals, &block)
-        @output ||= JSX::transform(data, JSX.transform_options)
+        @output ||= JSX::transform(data)
       end
     end
   end

--- a/lib/react/jsx/transformer.rb
+++ b/lib/react/jsx/transformer.rb
@@ -4,9 +4,12 @@ module React
       DEFAULT_ASSET_PATH = 'JSXTransformer.js'
 
       def initialize(options)
-        @strip_types =  options.fetch(:strip_types, false)
-        @harmony =      options.fetch(:harmony, false)
-        @asset_path =    options.fetch(:asset_path, DEFAULT_ASSET_PATH)
+        @transform_options = {
+          stripTypes: options.fetch(:strip_types, false),
+          harmony:    options.fetch(:harmony, false),
+        }
+
+        @asset_path = options.fetch(:asset_path, DEFAULT_ASSET_PATH)
 
         # If execjs uses therubyracer, there is no 'global'. Make sure
         # we have it so JSX script can work properly.
@@ -16,7 +19,7 @@ module React
 
 
       def transform(code)
-        result = @context.call('JSXTransformer.transform', code, {stripTypes: @strip_types, harmony: @harmony})
+        result = @context.call('JSXTransformer.transform', code, @transform_options)
         result["code"]
       end
 

--- a/lib/react/jsx/transformer.rb
+++ b/lib/react/jsx/transformer.rb
@@ -1,0 +1,30 @@
+module React
+  module JSX
+    class Transformer
+      DEFAULT_ASSET_PATH = 'JSXTransformer.js'
+
+      def initialize(options)
+        @strip_types =  options.fetch(:strip_types, false)
+        @harmony =      options.fetch(:harmony, false)
+        @asset_path =    options.fetch(:asset_path, DEFAULT_ASSET_PATH)
+
+        # If execjs uses therubyracer, there is no 'global'. Make sure
+        # we have it so JSX script can work properly.
+        js_code = 'var global = global || this;' + jsx_transform_code
+        @context = ExecJS.compile(js_code)
+      end
+
+
+      def transform(code)
+        result = @context.call('JSXTransformer.transform', code, {stripTypes: @strip_types, harmony: @harmony})
+        result["code"]
+      end
+
+      def jsx_transform_code
+        # search for transformer file using sprockets - allows user to override
+        # this file in his own application
+        ::Rails.application.assets[@asset_path].to_s
+      end
+    end
+  end
+end

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -12,13 +12,7 @@ class ReactTest < ActionDispatch::IntegrationTest
     app_react_file_path = File.expand_path("../dummy/vendor/assets/javascripts/react.js",  __FILE__)
     react_file_token = "'test_confirmation_token_react_content_non_production';\n"
     File.write(app_react_file_path, react_file_token)
-
-    react_asset = Rails.application.assets['react.js']
-
-    # Sprockets 2 doesn't expire this asset correctly,
-    # so override `fresh?` to mark it as expired.
-    def react_asset.fresh?(env); false; end
-
+    manually_expire_asset("react.js")
     react_asset = Rails.application.assets['react.js']
 
     get '/assets/react.js'

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -1,12 +1,11 @@
 require 'test_helper'
 class ReactTest < ActionDispatch::IntegrationTest
   setup do
-    FileUtils.rm_r(CACHE_PATH) if CACHE_PATH.exist?
-
+    clear_sprockets_cache
   end
 
   teardown do
-    FileUtils.rm_r(CACHE_PATH) if CACHE_PATH.exist?
+    clear_sprockets_cache
   end
 
   test 'asset pipeline should deliver drop-in react file replacement' do
@@ -25,7 +24,6 @@ class ReactTest < ActionDispatch::IntegrationTest
     get '/assets/react.js'
 
     File.unlink(app_react_file_path)
-    FileUtils.rm_r(CACHE_PATH) if CACHE_PATH.exist?
 
     assert_response :success
     assert_equal react_file_token.length, react_asset.to_s.length, "The asset pipeline serves the drop-in file"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,14 @@ def clear_sprockets_cache
   end
 end
 
+# Sprockets 2 doesn't expire this assets well in
+# this kind of setting,
+# so override `fresh?` to mark it as expired.
+def manually_expire_asset(asset_name)
+  asset = Rails.application.assets[asset_name]
+  def asset.fresh?(env); false; end
+end
+
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,10 +11,12 @@ CACHE_PATH = Pathname.new File.expand_path("../dummy/tmp/cache",  __FILE__)
 
 Rails.backtrace_cleaner.remove_silencers!
 
-# Remove cached files
-Rails.root.join('tmp/cache').tap do |tmp|
-  tmp.rmtree if tmp.exist?
-  tmp.mkpath
+def clear_sprockets_cache
+  # Remove cached files
+  Rails.root.join('tmp/cache').tap do |tmp|
+    tmp.rmtree if tmp.exist?
+    tmp.mkpath
+  end
 end
 
 # Load support files


### PR DESCRIPTION
Simplifying the `JSX` module and providing the feature from #239 

- Use an instance of `JSX::Transformer` for transforming JSX
- `JSX.transform_options` are initialization options for `Transformer`
- feature: allow custom JSX files by passing `asset_path:` config (or even overriding `Transformer#jsx_transform_code` :grimacing: )