### PR TITLE
Add `tilt` dependency

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 3.1'
   # If you change this, make sure to update VERSIONS.md:
   s.add_dependency 'react-source', '~> 0.13'
+  s.add_dependency 'tilt'
 
   s.files = Dir[
     'lib/**/*',


### PR DESCRIPTION
Same issue as #243 and #248.

This is a greater issue than just Rspec failing. rails g scaffold and several other commands that touch the dependency fail.