### PR TITLE
This changes "::" in the component name in the react_component helper to "."

### DIFF
--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -5,6 +5,9 @@ module React
       # are used by react_ujs to actually instantiate the React component
       # on the client.
       def react_component(name, props = {}, options = {}, &block)
+        
+        name = name.gsub("::",".") # allows ruby style naming
+        
         options = {:tag => options} if options.is_a?(Symbol)
 
         prerender_options = options[:prerender]

--- a/test/dummy/app/assets/javascripts/components/Todo.js.jsx.coffee
+++ b/test/dummy/app/assets/javascripts/components/Todo.js.jsx.coffee
@@ -5,3 +5,5 @@ Todo = React.createClass
 # Because Coffee files are in an anonymous function,
 # expose it for server rendering tests
 window.Todo = Todo
+# expose second example for nested names
+window.Lib.Todo = Todo

--- a/test/react/rails/view_helper_test.rb
+++ b/test/react/rails/view_helper_test.rb
@@ -46,6 +46,11 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
     assert(html.include?('>render on the server</li>'), "it includes rendered HTML")
     assert(html.include?('data-reactid'), "it includes React properties")
   end
+  
+  test 'react_component will translate :: to . in the component name' do
+    html = @helper.react_component('Lib::Todo', {}, prerender: true)
+    assert(html.include?('data-react-class="Lib.Todo"'), "it includes attrs for UJS")
+  end
 
   test 'react_component passes :static to SprocketsRenderer' do
     html = @helper.react_component('Todo', {todo: 'render on the server'}.to_json, prerender: :static)


### PR DESCRIPTION
So that opal react components read nicely when using react-rails

I did not see how to run the tests but I added a test hopefully