### PR TITLE
[testing] Execjs runtime benchmarks

### DIFF
--- a/benchmarks/server_rendering_benchmark.rb
+++ b/benchmarks/server_rendering_benchmark.rb
@@ -1,0 +1,51 @@
+# - `gem install duktape`
+# - Remove `JavaScriptCore` from RUNTIMES if you're not on mac
+# - `ruby -I lib  benchmarks/server_rendering_benchmark.rb`
+
+require 'react-rails'
+require 'duktape'
+require 'benchmark'
+
+SLOW_COMPONENT = "
+var SlowComponent = React.createClass({
+  render: function() {
+    var rand = 0
+    for (var i = 0; i < 10000; i++) {
+      rand = rand + (Math.random() * i)
+    }
+    return React.createElement('h1', rand + ' :)')
+  }
+})
+"
+
+REACT_JS_PATH = File.expand_path("../../vendor/react/react.js", __FILE__)
+JS_CODE = File.read(REACT_JS_PATH) + SLOW_COMPONENT
+
+React::ServerRendering.renderer = React::ServerRendering::ExecJSRenderer
+React::ServerRendering.renderer_options = {code: JS_CODE}
+React::ServerRendering.pool_timeout = 10
+
+def test_runtime(runtime, renders:, pool_size:)
+  ExecJS.runtime = runtime
+  React::ServerRendering.pool_size = pool_size
+  React::ServerRendering.reset_pool
+
+  renders.times do
+    React::ServerRendering.render("SlowComponent", {}, {})
+  end
+end
+
+RUNTIMES = [
+  ExecJS::Runtimes::RubyRacer,
+  ExecJS::Runtimes::Duktape,
+  ExecJS::Runtimes::JavaScriptCore,
+  ExecJS::Runtimes::Node,
+]
+
+Benchmark.bm(25) do |x|
+  [1, 10, 25].each do |pool_size|
+    RUNTIMES.each do |runtime|
+      x.report("#{runtime.name}, #{pool_size}x") { test_runtime(runtime, renders: 50, pool_size: pool_size)}
+    end
+  end
+end

--- a/lib/react/server_rendering.rb
+++ b/lib/react/server_rendering.rb
@@ -1,5 +1,6 @@
 require 'connection_pool'
 require 'react/server_rendering/sprockets_renderer'
+require 'react/server_rendering/exec_js_renderer'
 
 module React
   module ServerRendering

--- a/lib/react/server_rendering/exec_js_renderer.rb
+++ b/lib/react/server_rendering/exec_js_renderer.rb
@@ -1,0 +1,31 @@
+module React
+  module ServerRendering
+    class ExecJSRenderer
+      def initialize(options={})
+        js_code = options.fetch(:code) || raise("Pass `code:` option to instantiate a JS context!")
+        @context = ExecJS.compile(js_code)
+      end
+
+      def render(component_name, props, prerender_options)
+        js_code = <<-JS
+          (function () {
+            var result = React.renderToString(React.createElement(#{component_name}, #{props}));
+            return result;
+          })()
+        JS
+
+        @context.eval(js_code)
+      rescue ExecJS::ProgramError => err
+        raise PrerenderError.new(component_name, props, err)
+      end
+
+      class PrerenderError < RuntimeError
+        def initialize(component_name, props, js_message)
+          message = ["Encountered error \"#{js_message}\" when prerendering #{component_name} with #{props}",
+                      js_message.backtrace.join("\n")].join("\n")
+          super(message)
+        end
+      end
+    end
+  end
+end

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -8,10 +8,19 @@ module React
         js_code = GLOBAL_WRAPPER + CONSOLE_POLYFILL
 
         filenames.each do |filename|
-          js_code << ::Rails.application.assets[filename].to_s
+          js_code << load_asset(filename)
         end
 
         @context = ExecJS.compile(js_code)
+      end
+
+      def load_asset(file)
+        if ::Rails.application.config.assets.compile
+          ::Rails.application.assets[file].to_s
+        else
+          asset_path = ActionView::Base.new.asset_path(file)
+          File.read(File.join(::Rails.public_path, asset_path))
+        end
       end
 
       def render(component_name, props, prerender_options)


### PR DESCRIPTION
(I don't really want to merge this, I just want to share some code & results) 

I ran some tests to compare ExecJS runtimes & connection pool sizes:

- I added `ExecJSRenderer` to sidestep the dependency on Rails asset pipeline
- I threw [duktape.rb](https://github.com/judofyr/duktape.rb) in the mix just for kicks
- update: try benchmark with lots of threads accessing the lock

## Results 

```
rmosolgo ~/code/react-rails $ ruby -I lib  benchmarks/server_rendering_benchmark.rb
                                          user     system      total        real
threaded, 1 conn, therubyracer (V8)   0.120000   0.010000   0.130000 (  0.127382)
threaded, 1 conn, Duktape             0.460000   0.010000   0.470000 (  0.465932)
threaded, 1 conn, JavaScriptCore      0.110000   0.250000   2.460000 (  2.487619)
threaded, 1 conn, Node.js (V8)        0.110000   0.250000   9.560000 (  9.504323)
threaded, 10 conn, therubyracer (V8)  0.070000   0.010000   0.080000 (  0.074837)
threaded, 10 conn, Duktape            1.480000   0.040000   1.520000 (  1.515937)
threaded, 10 conn, JavaScriptCore     0.080000   0.230000   3.840000 (  0.932142)
threaded, 10 conn, Node.js (V8)       0.140000   0.250000  16.970000 (  3.768226)
threaded, 25 conn, therubyracer (V8)  0.060000   0.010000   0.070000 (  0.068196)
threaded, 25 conn, Duktape            3.170000   0.060000   3.230000 (  3.230653)
threaded, 25 conn, JavaScriptCore     0.190000   0.300000   4.240000 (  1.856800)
threaded, 25 conn, Node.js (V8)       0.080000   0.240000  17.570000 (  5.963759)
1 conn, therubyracer (V8)             0.070000   0.010000   0.080000 (  0.080440)
1 conn, Duktape                       0.470000   0.020000   0.490000 (  0.480219)
1 conn, JavaScriptCore                0.090000   0.230000   2.400000 (  2.442591)
1 conn, Node.js (V8)                  0.100000   0.250000   9.360000 (  9.294853)
10 conn, therubyracer (V8)            0.060000   0.010000   0.070000 (  0.079364)
10 conn, Duktape                      1.530000   0.040000   1.570000 (  1.558580)
10 conn, JavaScriptCore               0.090000   0.260000   4.050000 (  0.994402)
10 conn, Node.js (V8)                 0.160000   0.270000  17.320000 (  3.884776)
25 conn, therubyracer (V8)            0.090000   0.010000   0.100000 (  0.094128)
25 conn, Duktape                      3.300000   0.070000   3.370000 (  3.371425)
25 conn, JavaScriptCore               0.080000   0.300000   4.890000 (  1.982959)
25 conn, Node.js (V8)                 0.220000   0.340000  23.380000 (  8.886694)
```

### Sorted
```
# Ruby Racer 

threaded, 1 conn, therubyracer (V8)   0.120000   0.010000   0.130000 (  0.127382)
threaded, 25 conn, therubyracer (V8)  0.060000   0.010000   0.070000 (  0.068196)
threaded, 10 conn, therubyracer (V8)  0.070000   0.010000   0.080000 (  0.074837)
1 conn, therubyracer (V8)             0.070000   0.010000   0.080000 (  0.080440)
10 conn, therubyracer (V8)            0.060000   0.010000   0.070000 (  0.079364)
25 conn, therubyracer (V8)            0.090000   0.010000   0.100000 (  0.094128)

# Duktape 

threaded, 1 conn, Duktape             0.460000   0.010000   0.470000 (  0.465932)
threaded, 10 conn, Duktape            1.480000   0.040000   1.520000 (  1.515937)
threaded, 25 conn, Duktape            3.170000   0.060000   3.230000 (  3.230653)
1 conn, Duktape                       0.470000   0.020000   0.490000 (  0.480219)
10 conn, Duktape                      1.530000   0.040000   1.570000 (  1.558580)
25 conn, Duktape                      3.300000   0.070000   3.370000 (  3.371425)

# JavaScriptCore

threaded, 1 conn, JavaScriptCore      0.110000   0.250000   2.460000 (  2.487619)
threaded, 10 conn, JavaScriptCore     0.080000   0.230000   3.840000 (  0.932142)
threaded, 25 conn, JavaScriptCore     0.190000   0.300000   4.240000 (  1.856800)
1 conn, JavaScriptCore                0.090000   0.230000   2.400000 (  2.442591)
10 conn, JavaScriptCore               0.090000   0.260000   4.050000 (  0.994402)
25 conn, JavaScriptCore               0.080000   0.300000   4.890000 (  1.982959)

# Node.js

threaded, 1 conn, Node.js (V8)        0.110000   0.250000   9.560000 (  9.504323)
threaded, 10 conn, Node.js (V8)       0.140000   0.250000  16.970000 (  3.768226)
threaded, 25 conn, Node.js (V8)       0.080000   0.240000  17.570000 (  5.963759)
1 conn, Node.js (V8)                  0.100000   0.250000   9.360000 (  9.294853)
10 conn, Node.js (V8)                 0.160000   0.270000  17.320000 (  3.884776)
25 conn, Node.js (V8)                 0.220000   0.340000  23.380000 (  8.886694)
```

## Takeaways 

- RubyRacer is the fastest
- Node.js speed _decreases_ with a larger connection pool
- Running in different threads _decreases_ speed