### PR TITLE
Inline props operations improvement

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -10,7 +10,6 @@
     CLASS_NAME_ATTR: 'data-react-class',
     PROPS_ATTR: 'data-react-props',
     PROPS_ID_ATTR: 'data-react-props-id',
-    SEPARATE_PROPS: <%= Rails.configuration.react.separate_props %>,
     RAILS_ENV_DEVELOPMENT: <%= Rails.env == "development" %>,
     // helper method for the mount and unmount methods to find the
     // `data-react-class` DOM elements
@@ -37,9 +36,8 @@
         // Fallback to eval to handle cases like 'My.React.ComponentName'.
         var constructor = window[className] || eval.call(window, className);
 
-
-        if (window.ReactRailsUJS.SEPARATE_PROPS) {
-            propsId = node.getAttribute(window.ReactRailsUJS.PROPS_ID_ATTR);
+        propsId = node.getAttribute(window.ReactRailsUJS.PROPS_ID_ATTR);
+        if (propsId != null) {
             propsElement = document.getElementById(propsId);
             propsJson = propsElement && propsElement.text;
         } else {

--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -8,7 +8,9 @@
   // create the  namespace
   window.ReactRailsUJS = {
     CLASS_NAME_ATTR: 'data-react-class',
+    PROPS_ATTR: 'data-react-props',
     PROPS_ID_ATTR: 'data-react-props-id',
+    SEPARATE_PROPS: <%= Rails.configuration.react.separate_props %>,
     RAILS_ENV_DEVELOPMENT: <%= Rails.env == "development" %>,
     // helper method for the mount and unmount methods to find the
     // `data-react-class` DOM elements
@@ -27,15 +29,23 @@
       var nodes = window.ReactRailsUJS.findDOMNodes();
 
       for (var i = 0; i < nodes.length; ++i) {
+        var propsId, propsElement, propsJson;
         var node = nodes[i];
         var className = node.getAttribute(window.ReactRailsUJS.CLASS_NAME_ATTR);
 
         // Assume className is simple and can be found at top-level (window).
         // Fallback to eval to handle cases like 'My.React.ComponentName'.
         var constructor = window[className] || eval.call(window, className);
-        var propsId = node.getAttribute(window.ReactRailsUJS.PROPS_ID_ATTR);
-        var propsElement = document.getElementById(propsId);
-        var propsJson = propsElement && propsElement.text;
+
+
+        if (window.ReactRailsUJS.SEPARATE_PROPS) {
+            propsId = node.getAttribute(window.ReactRailsUJS.PROPS_ID_ATTR);
+            propsElement = document.getElementById(propsId);
+            propsJson = propsElement && propsElement.text;
+        } else {
+            propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
+        }
+
         var props = propsJson && JSON.parse(propsJson);
 
         React.render(React.createElement(constructor, props), node);

--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -8,7 +8,7 @@
   // create the  namespace
   window.ReactRailsUJS = {
     CLASS_NAME_ATTR: 'data-react-class',
-    PROPS_ATTR: 'data-react-props',
+    PROPS_ID_ATTR: 'data-react-props-id',
     RAILS_ENV_DEVELOPMENT: <%= Rails.env == "development" %>,
     // helper method for the mount and unmount methods to find the
     // `data-react-class` DOM elements
@@ -33,7 +33,9 @@
         // Assume className is simple and can be found at top-level (window).
         // Fallback to eval to handle cases like 'My.React.ComponentName'.
         var constructor = window[className] || eval.call(window, className);
-        var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
+        var propsId = node.getAttribute(window.ReactRailsUJS.PROPS_ID_ATTR);
+        var propsElement = document.getElementById(propsId);
+        var propsJson = propsElement && propsElement.text;
         var props = propsJson && JSON.parse(propsJson);
 
         React.render(React.createElement(constructor, props), node);

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -9,6 +9,8 @@ module React
       config.react.variant = (::Rails.env.production? ? :production : :development)
       config.react.addons = false
       config.react.jsx_transform_options = {}
+      config.react.separate_props = false
+
       # Server-side rendering
       config.react.max_renderers = 10
       config.react.timeout = 20 #seconds

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -9,7 +9,6 @@ module React
       config.react.variant = (::Rails.env.production? ? :production : :development)
       config.react.addons = false
       config.react.jsx_transform_options = {}
-      config.react.separate_props = false
 
       # Server-side rendering
       config.react.max_renderers = 10

--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -51,7 +51,7 @@ module React
       # in order to speedup page rendering.
       #
       def render_react_props(element_id=nil)
-        content_for("react_props_#{element_id}") || content_for('react_props') || nil
+        element_id.nil? && content_for('react_props') || content_for("react_props_#{element_id}")
       end
 
     end

--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -13,7 +13,7 @@ module React
         html_options = options.reverse_merge(:data => {})
         html_options[:data].tap do |data|
           data[:react_class] = name
-          data[:react_props] = React::Renderer.react_props(args) unless args.empty?
+          data[:react_props_id] = add_react_props args
         end
         html_tag = html_options[:tag] || :div
         
@@ -21,6 +21,26 @@ module React
         html_options.except!(:tag, :prerender)
         
         content_tag(html_tag, '', html_options, &block)
+      end
+
+      # Add properties for component and return element id.
+      #
+      def add_react_props(props={})
+        return if props.empty?
+        props_id = SecureRandom.base64
+        content_for :react_props do
+          content_tag :script, type: 'text/json', id: props_id do
+            raw React::Renderer.react_props props
+          end
+        end
+        props_id
+      end
+
+      # Render script tag with JSON props. Should be placed at the end of body
+      # in order to speedup page rendering.
+      #
+      def render_react_props
+        content_for :react_props
       end
 
     end

--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -13,22 +13,31 @@ module React
         html_options = options.reverse_merge(:data => {})
         html_options[:data].tap do |data|
           data[:react_class] = name
-          data[:react_props_id] = add_react_props args
+          next if args.empty?
+          if react_separate_props?
+            data[:react_props_id] = add_react_props args, options[:inline_props]
+          else
+            data[:react_props] = React::Renderer.react_props args
+          end
         end
         html_tag = html_options[:tag] || :div
         
         # remove internally used properties so they aren't rendered to DOM
         html_options.except!(:tag, :prerender)
-        
-        content_tag(html_tag, '', html_options, &block)
+
+        result = content_tag(html_tag, '', html_options, &block)
+        result += render_react_props html_options[:data][:react_props_id] if options[:inline_props] && react_separate_props?
+        result
       end
 
       # Add properties for component and return element id.
       #
-      def add_react_props(props={})
+      def add_react_props(props={}, inline=false)
         return if props.empty?
         props_id = SecureRandom.base64
-        content_for :react_props do
+        content_key = "react_props"
+        content_key += "_#{props_id}" if inline
+        content_for content_key do
           content_tag :script, type: 'text/json', id: props_id do
             raw React::Renderer.react_props props
           end
@@ -39,8 +48,16 @@ module React
       # Render script tag with JSON props. Should be placed at the end of body
       # in order to speedup page rendering.
       #
-      def render_react_props
-        content_for :react_props
+      def render_react_props(element_id=nil)
+        if react_separate_props?
+          content_for("react_props_#{element_id}") || content_for('react_props')
+        else
+          nil
+        end
+      end
+
+      def react_separate_props?
+        ::Rails.configuration.react.separate_props
       end
 
     end

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'jbuilder'
 
   s.add_dependency 'execjs'
-  s.add_dependency 'coffee-script-source', '~>1.9'
+  s.add_dependency 'coffee-script-source', '~>1.8'
   s.add_dependency 'rails', '>= 3.1'
   s.add_dependency 'react-source', '~> 0.12'
   s.add_dependency 'connection_pool'

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'jbuilder'
 
   s.add_dependency 'execjs'
-  s.add_dependency 'coffee-script-source', '~>1.8'
+  s.add_dependency 'coffee-script-source', '~>1.9'
   s.add_dependency 'rails', '>= 3.1'
   s.add_dependency 'react-source', '~> 0.12'
   s.add_dependency 'connection_pool'

--- a/test/dummy/app/controllers/separate_controller.rb
+++ b/test/dummy/app/controllers/separate_controller.rb
@@ -1,0 +1,2 @@
+class SeparateController < ServerController
+end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -10,5 +10,9 @@
 
 <%= yield %>
 
+<div id="dummy"></div>
+
+<%= render_react_props %>
+
 </body>
 </html>

--- a/test/dummy/app/views/separate/show.html.erb
+++ b/test/dummy/app/views/separate/show.html.erb
@@ -1,0 +1,1 @@
+<%= react_component "TodoList", {:todos => @todos}, :prerender => true, :separate_props => true, :move_separate_props_out => params[:move_separate_props_out] %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Dummy::Application.routes.draw do
   resources :pages, :only => [:show]
   resources :server, :only => [:show]
+  resources :separate, :only => [:show]
 end

--- a/test/view_helper_test.rb
+++ b/test/view_helper_test.rb
@@ -55,7 +55,7 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
   end
 
   test 'react_component can render separate props moved to any place in DOM' do
-    @helper.react_component "TodoList", {:todos => %w(todo1 todo2, todo3)},
+    html = @helper.react_component "TodoList", {:todos => %w(todo1 todo2, todo3)},
                             :prerender => true,
                             :separate_props => true,
                             :move_separate_props_out => true

--- a/test/view_helper_test.rb
+++ b/test/view_helper_test.rb
@@ -52,7 +52,7 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
   test 'react_component can render separate props inline' do
     get '/separate/1'
     inline_props_id = response.body.scan(/data-react-props-id="([^"]+)/).flatten.first
-    assert_not inline_props_id.nil?
+    assert !inline_props_id.nil?
     dummy_index = response.body.index '<div id="dummy">'
     inline_props_index = response.body.index("<script id=\"#{inline_props_id}\" type=\"text/json\">")
     assert inline_props_index < dummy_index
@@ -61,7 +61,7 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
   test 'react_component can render separate props moved to any place in DOM' do
     get '/separate/1?move_separate_props_out=true'
     moved_props_id = response.body.scan(/data-react-props-id="([^"]+)/).flatten.first
-    assert_not moved_props_id.nil?
+    assert !moved_props_id.nil?
     dummy_index = response.body.index '<div id="dummy">'
     moved_props_index = response.body.index("<script id=\"#{moved_props_id}\" type=\"text/json\">")
     assert moved_props_index > dummy_index

--- a/test/view_helper_test.rb
+++ b/test/view_helper_test.rb
@@ -51,6 +51,7 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
 
   test 'react_component can render separate props inline' do
     html = @helper.react_component "TodoList", {:todos => %w(todo1 todo2, todo3)}, :prerender => true, :separate_props => true
+    assert_match /data-react-class=\"TodoList\"/, html
     assert_match /{"todos":\["todo1","todo2,","todo3"\]}<\/script>$/, html
   end
 
@@ -59,6 +60,7 @@ class ViewHelperTest < ActionDispatch::IntegrationTest
                             :prerender => true,
                             :separate_props => true,
                             :move_separate_props_out => true
+    assert_match /data-react-class=\"TodoList\"/, html
     assert_no_match /{"todos":\["todo1","todo2,","todo3"\]}<\/script>$/, html
     props_tag = @helper.render_react_props
     assert_not_empty props_tag


### PR DESCRIPTION
# Problem
1. Size of inline props placed to the root component tag as attributes may be too huge to:
  1.1 Process in browser devtools. So that browser stucks trying to render markup for preview.
  1.2 Deliver it to user due to bandwidth (for highload apps).
2. Inline props placed to the attributes of tag are looking freaky because of its size and HTML safety.

So props we want to place:
```JSON
{"foo": "bar"}
```
are looking like this:
```HTML
{&quot;foo&quot;:&quot;bar&quot;}
```

# Solution
Moving inline props to the ```<script type="text/json">{"foo": "bar"}</script>``` will:
1. Reduce the size of data passed to the page in order to render component at the initial state. It's also useful because it reduces bandwidth utilization (even if we are using GZIP).
2. Allow browser inspector to operate on DOM faster.
3. Make markup looking more cleaner.

Placing inline props at the end of body speeds up DOM rendering and allows Turbolinks to load this data along with other markup on each request.

# How it works
The process of placing the components to the markup in Rails is still the same except of developer should add ```<%= render_react_props %>``` at the end of ```<body>``` tag.
