### PR TITLE
update therubyracer for tests

### DIFF
--- a/gemfiles/rails_4.0_with_therubyracer.gemfile
+++ b/gemfiles/rails_4.0_with_therubyracer.gemfile
@@ -3,6 +3,6 @@
 source "http://rubygems.org"
 
 gem "rails", "~> 4.0.13"
-gem "therubyracer", "0.12.0", :platform => :mri
+gem "therubyracer", "0.12.2", :platform => :mri
 
 gemspec :path => "../"


### PR DESCRIPTION
Ug, somehow I caused the test suite to fail in #302.

- 1.9.3 & JRuby fail on a `%i(...)` (but why now and not before?)
- Others fail on a `Segmentation fault` during JS execution :weary: 