### PR TITLE
Fix running on sprockets-rails master

### DIFF
--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -3,7 +3,7 @@ module React
     class Engine < ::Rails::Engine
       initializer "react_rails.setup_engine", :group => :all do |app|
         if app.assets.nil?
-         app.config.assets.register_engine '.jsx', React::JSX::Template
+          Sprockets.register_engine  '.jsx', React::JSX::Template
         else
           app.assets.register_engine '.jsx', React::JSX::Template
         end

--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -2,7 +2,11 @@ module React
   module Rails
     class Engine < ::Rails::Engine
       initializer "react_rails.setup_engine", :group => :all do |app|
-        app.assets.register_engine '.jsx', React::JSX::Template
+        if app.assets.nil?
+         app.config.assets.register_engine '.jsx', React::JSX::Template
+        else
+          app.assets.register_engine '.jsx', React::JSX::Template
+        end
       end
     end
   end

--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -2,11 +2,8 @@ module React
   module Rails
     class Engine < ::Rails::Engine
       initializer "react_rails.setup_engine", :group => :all do |app|
-        if app.assets.nil?
-          Sprockets.register_engine  '.jsx', React::JSX::Template
-        else
-          app.assets.register_engine '.jsx', React::JSX::Template
-        end
+        sprockets_env = app.assets || Sprockets # Sprockets 3.x expects this in a different place
+        sprockets_env.register_engine(".jsx", React::JSX::Template)
       end
     end
   end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -38,10 +38,12 @@ module React
           addons: app.config.react.addons,
         })
 
-        app.assets.version = [
-          app.assets.version,
-          "react-#{asset_variant.react_build}",
-        ].compact.join('-')
+        if app.assets.nil?
+          app.config.assets.version = [app.config.assets.version, "react-#{asset_variant.react_build}",].compact.join('-')
+        else
+          app.assets.version = [app.assets.version, "react-#{asset_variant.react_build}",].compact.join('-')
+        end
+
       end
 
       config.before_initialize do |app|

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -38,11 +38,8 @@ module React
           addons: app.config.react.addons,
         })
 
-        if app.assets.nil?
-          app.config.assets.version = [app.config.assets.version, "react-#{asset_variant.react_build}",].compact.join('-')
-        else
-          app.assets.version = [app.assets.version, "react-#{asset_variant.react_build}",].compact.join('-')
-        end
+        sprockets_env = app.assets || app.config.assets # sprockets-rails 3.x attaches this at a different config
+        sprockets_env.version = [sprockets_env.version, "react-#{asset_variant.react_build}",].compact.join('-')
 
       end
 


### PR DESCRIPTION
- Assets version and register_engine have been moved from app.assets to app.config.assets on sprockets
- Added a check to make sure to use proper asset object when calling version, register_engine, etc