### PR TITLE
Allow to pass DOM object as parent selector.

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -14,17 +14,29 @@
     // `data-react-class` DOM elements
     findDOMNodes: function(searchSelector) {
       // we will use fully qualified paths as we do not bind the callbacks
-      var selector;
-      if (typeof searchSelector === 'undefined') {
-        var selector = '[' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']';
-      } else {
-        var selector = searchSelector + ' [' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']';
+      var selector, parent;
+
+      switch (typeof searchSelector) {
+        case 'undefined':
+          selector = '[' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']';
+          parent = document;
+          break;
+        case 'object':
+          selector = '[' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']';
+          parent = searchSelector;
+          break;
+        case 'string':
+          selector = searchSelector + '[' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']';
+          parent = document;
+          break
+        default:
+          break;
       }
 
       if ($) {
-        return $(selector);
+        return $(selector, parent);
       } else {
-        return document.querySelectorAll(selector);
+        return parent.querySelectorAll(selector);
       }
     },
 


### PR DESCRIPTION
Extend possibility of `findDOMNodes` and as a consequence `mountComponents`. It allows to use it with an element which was inserted to the DOM tree without react.js. Example:

```
$(document).on('nested:fieldAdded', function(e) {
  window.ReactRailsUJS.mountComponents(e.target);
});
```

With backward compatibility, of course.