### PR TITLE
Make server rendering more efficient

### DIFF
--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -5,6 +5,11 @@ module React
         sprockets_env = app.assets || Sprockets # Sprockets 3.x expects this in a different place
         sprockets_env.register_engine(".jsx", React::JSX::Template)
       end
+
+      initializer 'react_rails.assets.precompile' do |app|
+        precompile = File.join("components", '*.ssr.js')
+        app.config.assets.precompile += [precompile]
+      end
     end
   end
 end

--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -12,7 +12,7 @@ module React
         if options[:use_ssr]
           # Since we are using server side rendering
           # we make sure prerender option is always not false
-          if prerender_options == false
+          if prerender_options == false || prerender_options.nil?
             prerender_options = true 
           end
           pre_options = {

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -1,3 +1,6 @@
+
+require 'multi_json'
+
 # Extends ExecJSRenderer for the Rails environment
 # - builds JS code out of the asset pipeline
 # - stringifies props
@@ -14,10 +17,19 @@ module React
           js_code << ::Rails.application.assets[filename].to_s
         end
 
+        @manifest_base ||= File.join(::Rails.public_path, ::Rails.application.config.assets.prefix)
+        load_asset_on_init
+
         super(options.merge(code: js_code))
       end
 
       def render(component_name, props, prerender_options)
+        if prerender_options.is_a?(Hash)
+          @controller_path = prerender_options.fetch(:controller_path)
+        else
+          @controller_path = nil 
+        end
+
         # pass prerender: :static to use renderToStaticMarkup
         react_render_method = if prerender_options == :static
             "renderToStaticMarkup"
@@ -30,6 +42,30 @@ module React
         end
 
         super(component_name, props, {render_function: react_render_method})
+      end
+
+      # When server rendering, we dont include the components in
+      # `components.js`
+      def before_render(component_name, props, prerender_options)
+        if @controller_path.nil?
+          return 
+        end
+
+        jscode = ''
+
+        success = false
+        # In production environment, load component from static
+        if ::Rails.env.production?
+          content, success = load_asset(entry)
+        end
+
+        if not success
+          jscode << ::Rails.application.assets[entry].to_s
+        else 
+          jscode << content
+        end
+
+        jscode
       end
 
       def after_render(component_name, props, prerender_options)
@@ -58,6 +94,75 @@ module React
           }
         })(console.history);
       JS
+
+      private 
+
+      def entry
+        components = 'components'
+        path = @controller_path.to_s.split('.').join('_')
+        File.join(components, "#{path}.ssr.js")
+      end
+
+      # Return asset content
+      def load_asset(filename)
+        digest_path = assets[filename]
+
+        if digest_path.nil?
+          return '', false 
+        end
+
+        file = File.join(@manifest_base, digest_path)
+        if not File.exist?(file)
+          return '', false 
+        end
+
+        return File.read(file), true
+      end
+
+      def assets
+        @data['assets'] ||= {}
+      end
+
+      def files
+        @data['files'] ||= {}
+      end
+
+      def load_asset_on_init
+        paths = Dir[File.join(@manifest_base, "manifest*.json")]
+        if paths.any?
+          path = paths.first
+        else 
+          paths = File.join(@manifest_base, "manifest.yml")
+          if !File.exist?(paths)
+            # No precompile
+            return {}
+          end
+          
+          data = ::YAML::load(File.read(paths))
+          @data = data.is_a?(Hash) ? data : {}
+          return @data
+        end
+
+        begin
+          if File.exist?(path)
+            data = json_decode(File.read(path))
+          end
+        rescue ::MultiJson::DecodeError => e
+          return {}
+        end
+
+        @data = data.is_a?(Hash) ? data : {}
+      end
+
+      if ::MultiJson.respond_to?(:dump)
+        def json_decode(obj)
+          ::MultiJson.load(obj)
+        end
+      else
+        def json_decode(obj)
+          ::MultiJson.decode(obj)
+        end
+      end
     end
   end
 end

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 3.2'
   s.add_dependency 'tilt'
   s.add_dependency 'babel-transpiler', '>=0.7.0'
+  s.add_dependency 'multi_json', '>= 1.0'
 
   s.files = Dir[
     'lib/**/*',


### PR DESCRIPTION
When server rendering, all components will be in components.js
and Execjs will evaluate the js code even some component is not
needed.

Add 'use_ssr' option, to only evaluate the component that specific by
controller. Note, when `use_ssr` is true, then there no need to provide
the `prerender: true` option.

```erb
react_component('Components.IndexView', {}, {use_ssr: true})
```

If `use_ssr` is not provided, then react-rails will works like before.

Here is an example: https://github.com/towry/rails-react-server-rendering-example.