### PR TITLE
Reposition asset path build

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -51,7 +51,7 @@ module React
 
       end
 
-      config.before_initialize do |app|
+      initializer "react_rails.set_variant", after: :engines_blank_point, group: :all do |app|
         asset_variant = React::Rails::AssetVariant.new({
           variant: app.config.react.variant,
           addons: app.config.react.addons,

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -26,6 +26,7 @@ module Dummy
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.react.variant = :production
+    config.react.addons = false
 
     config.assets.enabled = true
   end

--- a/test/dummy/config/initializers/react.rb
+++ b/test/dummy/config/initializers/react.rb
@@ -1,0 +1,2 @@
+# Override setting set in application.rb
+Rails.application.config.react.addons = true

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -35,8 +35,8 @@ class ReactTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "the development version is loaded" do
+  test "the development version with addons is loaded" do
     asset = Rails.application.assets.find_asset('react')
-    assert asset.pathname.to_s.end_with?('development/react.js')
+    assert asset.pathname.to_s.end_with?('development-with-addons/react.js')
   end
 end


### PR DESCRIPTION
The standard config/initializers are only run after `railtie#before_initialize`, but we have to build the asset paths before `railtie#after_initialize` since at that point Sprockets has already frozen the asset paths.

This PR moves the asset path build to a point in between `before_initialize` and `after_initialize`, after the standard initializers are run but before Sprockets freezes the environment.

Fixes #345 