### PR TITLE
findDOMNodes(): Support jquery selectors

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -13,6 +13,10 @@
     // helper method for the mount and unmount methods to find the
     // `data-react-class` DOM elements
     findDOMNodes: function(searchSelector) {
+      if ($ && searchSelector instanceof $) {
+        return searchSelector.find('[' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']');
+      }
+
       // we will use fully qualified paths as we do not bind the callbacks
       var selector;
       if (typeof searchSelector === 'undefined') {


### PR DESCRIPTION
In my use case, I need to initialize react components in a context referenced only by a jquery object. Trust me there is little I can do to get a CSS selector instead of this object in this use case I'm working on. However, `ReactRailsUJS.mountComponents()` Only supports string CSS selectors. 

There is no simple way to get a string CSS selector from a dom node or jquery object.

With much simplicity, this adds much value by enabling support for jquery objects passed to `ReactRailsUJS.mountComponents()`.

I hope you find this useful, feel free to re-work any way that suits you.