### PR TITLE
Support ReactDOM in react_ujs

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -53,7 +53,10 @@
         var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
         var props = propsJson && JSON.parse(propsJson);
 
-        React.render(React.createElement(constructor, props), node);
+        // Prefer ReactDOM if defined (introduced in 0.14)
+        var renderer = (typeof ReactDOM == "object") ? ReactDOM : React;
+
+        renderer.render(React.createElement(constructor, props), node);
       }
     },
 


### PR DESCRIPTION
In 0.14, we now have `ReactDOM`. Prefer it for now to get rid of errors in the console.