### PR TITLE
Support ReactDOM in react_ujs for unmountComponents

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -66,7 +66,9 @@
       for (var i = 0; i < nodes.length; ++i) {
         var node = nodes[i];
 
-        React.unmountComponentAtNode(node);
+        // Prefer ReactDOM if defined (introduced in 0.14)
+        var renderer = (typeof ReactDOM == "object") ? ReactDOM : React;
+        renderer.unmountComponentAtNode(node);
       }
     }
   };


### PR DESCRIPTION
Same fix as #366, but for `unmountComponents`