### PR TITLE
Add ability to render custom attributes from the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,14 @@ Components can also be prerendered directly from a controller action with the cu
 class TodoController < ApplicationController
   def index
     @todos = Todo.all
-    render component: 'TodoList', props: { todos: @todos }, tag: 'span'
+    render component: 'TodoList', props: { todos: @todos }, tag: 'span', class: 'todo'
   end
 end
 ```
 
 This custom renderer behaves the same as a normal view renderer and accepts the usual arguments - `content_type`, `layout`, `location` and `status`.
-By default, your current layout will be used and the component, rather than a view, will be rendered in place of `yield`.
+By default, your current layout will be used and the component, rather than a view, will be rendered in place of `yield`. Custom data-* attributes
+can be passed like `data: {remote: true}`.
 
 ### Component generator
 

--- a/lib/react/rails/controller_renderer.rb
+++ b/lib/react/rails/controller_renderer.rb
@@ -12,7 +12,7 @@ class React::Rails::ControllerRenderer
 
   def call(name, options, &block)
     props = options.fetch(:props, {})
-    options = options.slice(:data, :tag).merge(prerender: true)
+    options = options.slice(:data, :aria, :tag, :class, :id).merge(prerender: true)
     react_component(name, props, options, &block)
   end
 end

--- a/test/dummy/app/controllers/server_controller.rb
+++ b/test/dummy/app/controllers/server_controller.rb
@@ -16,6 +16,11 @@ class ServerController < ApplicationController
   end
 
   def inline_component
-    render component: 'TodoList', props: { todos: ['Render this inline'] }, tag: 'span'
+    render component: 'TodoList',
+           props: { todos: ['Render this inline'] },
+           tag: 'span',
+           class: 'custom-class',
+           id: 'custom-id',
+           data: { remote: true }
   end
 end

--- a/test/server_rendered_html_test.rb
+++ b/test/server_rendered_html_test.rb
@@ -55,11 +55,15 @@ class ServerRenderedHtmlTest  < ActionDispatch::IntegrationTest
   test 'react inline component rendering' do
     get '/server/inline_component'
     rendered_html = response.body
-    assert_match(/<span data-react-class=\"TodoList\"/, rendered_html)
+    assert_match(/<span.*data-react-class=\"TodoList\"/, rendered_html)
     # make sure that the items are prerendered
     assert_match(/Render this inline/, rendered_html)
     assert_match(/<\/ul><\/span>/, rendered_html, "it accepts a tag override")
     # make sure that the layout is rendered with the component
     assert_match(/<title>Dummy<\/title>/, rendered_html)
+    # make sure that custom html attributes are rendered
+    assert_match(/class=\"custom-class\"/, rendered_html)
+    assert_match(/id=\"custom-id\"/, rendered_html)
+    assert_match(/data-remote=\"true\"/, rendered_html)
   end
 end


### PR DESCRIPTION
Currently, all custom attributes are sliced from options  when using the controller renderer, instead of forwarding it to the view helper, making it impossible to set a custom class name or id.

This patch changes the behaviour to act more like render_component.