### PR TITLE
Switch to the new Sprockets processor

### DIFF
--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -1,4 +1,5 @@
 require 'execjs'
+require 'react/jsx/processor'
 require 'react/jsx/template'
 require 'react/jsx/jsx_transformer'
 require 'react/jsx/babel_transformer'

--- a/lib/react/jsx/processor.rb
+++ b/lib/react/jsx/processor.rb
@@ -1,16 +1,8 @@
 module React
   module JSX
     class Processor
-      def self.instance
-        @instance ||= new
-      end
-      
       def self.call(input)
-        instance.call(input)
-      end
-
-      def call(input)
-        {data: JSX::transform(input[:data])}
+        JSX::transform(input[:data])
       end
     end
   end

--- a/lib/react/jsx/processor.rb
+++ b/lib/react/jsx/processor.rb
@@ -1,0 +1,17 @@
+module React
+  module JSX
+    class Processor
+      def self.instance
+        @instance ||= new
+      end
+      
+      def self.call(input)
+        instance.call(input)
+      end
+
+      def call(input)
+        {data: JSX::transform(input[:data])}
+      end
+    end
+  end
+end

--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -3,7 +3,12 @@ module React
     class Engine < ::Rails::Engine
       initializer "react_rails.setup_engine", :group => :all do |app|
         sprockets_env = app.assets || Sprockets # Sprockets 3.x expects this in a different place
-        sprockets_env.register_engine(".jsx", React::JSX::Template)
+        if Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new("3.0.0")
+          sprockets_env.register_mime_type("application/jsx", extensions: [".jsx", ".js.jsx"])
+          sprockets_env.register_transformer("application/jsx", "application/javascript", React::JSX::Processor)
+        else
+          sprockets_env.register_engine(".jsx", React::JSX::Template)
+        end
       end
     end
   end

--- a/test/react/jsx/jsx_transformer_test.rb
+++ b/test/react/jsx/jsx_transformer_test.rb
@@ -19,7 +19,7 @@ class JSXTransformerTest < ActionDispatch::IntegrationTest
     FileUtils.rm replacing_path
 
     assert_response :success
-    assert_equal 'test_confirmation_token_jsx_transformed;', @response.body
+    assert_equal 'test_confirmation_token_jsx_transformed;', @response.body.strip
   end
 
   test 'accepts harmony: true option' do
@@ -52,7 +52,7 @@ class JSXTransformerTest < ActionDispatch::IntegrationTest
 
     FileUtils.rm_rf custom_path
     assert_response :success
-    assert_equal 'test_confirmation_token_jsx_transformed;', @response.body
+    assert_equal 'test_confirmation_token_jsx_transformed;', @response.body.strip
   end
 
 end


### PR DESCRIPTION
Starting version 4 Sprockets is removing the `register_engine` method which registers JSX transformers using Tilt based templates breaking this gem for the current Rails 5 `master`. This has been deprecated since Sprockets version 3:
https://github.com/rails/sprockets/blob/master/UPGRADING.md

This PR adds a JSX Processor and registers it via `register_processor` as `application/jsx` mime type. Is there a reserved mime type for JSX templates?