### PR TITLE
Update README to hint for newer syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,14 @@ Component = React.createClass
     `<ExampleComponent videos={this.props.videos} />`
 ```
 
+Alternatively, the newer ES6 style class based syntax can be used like this:
+
+```coffee
+class Component extends React.Component
+  render: ->
+    `<ExampleComponent videos={this.props.videos} />`
+```
+
 ## Extending `react-rails`
 
 You can extend some of the core functionality of `react-rails` by injecting new implementations during configuration.


### PR DESCRIPTION
Since React 0.12 the ES6 style syntax can be used with CoffeeScript classes as well. The docs should give a hint for this.