### PR TITLE
Fix ExecJSRenderer interface

### DIFF
--- a/lib/react/server_rendering/exec_js_renderer.rb
+++ b/lib/react/server_rendering/exec_js_renderer.rb
@@ -11,7 +11,17 @@ module React
       end
 
       def render(component_name, props, prerender_options)
-        render_function = prerender_options.fetch(:render_function, "renderToString")
+        # pass prerender: :static to use renderToStaticMarkup
+        render_function = if prerender_options == :static
+            "renderToStaticMarkup"
+          else
+            "renderToString"
+          end
+
+        if !props.is_a?(String)
+          props = props.to_json
+        end
+
         js_code = <<-JS
           (function () {
             #{before_render(component_name, props, prerender_options)}

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -17,21 +17,6 @@ module React
         super(options.merge(code: js_code))
       end
 
-      def render(component_name, props, prerender_options)
-        # pass prerender: :static to use renderToStaticMarkup
-        react_render_method = if prerender_options == :static
-            "renderToStaticMarkup"
-          else
-            "renderToString"
-          end
-
-        if !props.is_a?(String)
-          props = props.to_json
-        end
-
-        super(component_name, props, {render_function: react_render_method})
-      end
-
       def after_render(component_name, props, prerender_options)
         @replay_console ? CONSOLE_REPLAY : ""
       end

--- a/test/dummy/app/controllers/server_controller.rb
+++ b/test/dummy/app/controllers/server_controller.rb
@@ -1,4 +1,16 @@
 class ServerController < ApplicationController
+  DUMMY_IMPLEMENTATION = "
+  var Todo = null
+  var React = {
+    createElement: function() {},
+  }
+  var ReactDOMServer = {
+    renderToString: function() {
+      return 'renderToString was called'
+    },
+  }
+  "
+
   def show
     @todos = %w{todo1 todo2 todo3}
   end
@@ -11,6 +23,13 @@ class ServerController < ApplicationController
 
   def console_example_suppressed
     React::ServerRendering.renderer_options = {replay_console:  false}
+    React::ServerRendering.reset_pool
+    @todos = %w{todo1 todo2 todo3}
+  end
+
+  def exec_js_renderer
+    React::ServerRendering.renderer = React::ServerRendering::ExecJSRenderer
+    React::ServerRendering.renderer_options[:code] = DUMMY_IMPLEMENTATION
     React::ServerRendering.reset_pool
     @todos = %w{todo1 todo2 todo3}
   end

--- a/test/dummy/app/views/server/exec_js_renderer.html.erb
+++ b/test/dummy/app/views/server/exec_js_renderer.html.erb
@@ -1,0 +1,1 @@
+<%= react_component "Todo", {todos: @todos}, {prerender: true} %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,6 +4,7 @@ Dummy::Application.routes.draw do
     collection do
       get :console_example
       get :console_example_suppressed
+      get :exec_js_renderer
       get :inline_component
     end
   end

--- a/test/react/server_rendering/exec_js_renderer_test.rb
+++ b/test/react/server_rendering/exec_js_renderer_test.rb
@@ -21,13 +21,13 @@ class ExecJSRendererTest < ActiveSupport::TestCase
   end
 
   test '#render returns HTML' do
-    result = @renderer.render("Todo", {todo: "write tests"}.to_json, {})
+    result = @renderer.render("Todo", {todo: "write tests"}.to_json, nil)
     assert_match(/<li.*write tests<\/li>/, result)
     assert_match(/data-react-checksum/, result)
   end
 
-  test '#render accepts render_function:' do
-    result = @renderer.render("Todo", {todo: "write more tests"}.to_json, render_function: "renderToStaticMarkup")
+  test '#render accepts :static pre-render option' do
+    result = @renderer.render("Todo", {todo: "write more tests"}.to_json, :static)
     assert_match(/<li>write more tests<\/li>/, result)
     assert_no_match(/data-react-checksum/, result)
   end
@@ -42,7 +42,7 @@ class ExecJSRendererTest < ActiveSupport::TestCase
     end
 
     error = assert_raises(React::ServerRendering::PrerenderError) do
-      @renderer.render("Todo", {todo: "write tests"}.to_json, {})
+      @renderer.render("Todo", {todo: "write tests"}.to_json, nil)
     end
 
     assert_match(/before_render/, error.message)
@@ -60,7 +60,7 @@ class ExecJSRendererTest < ActiveSupport::TestCase
     end
 
     error = assert_raises(React::ServerRendering::PrerenderError) do
-      @renderer.render("Todo", {todo: "write tests"}.to_json, {})
+      @renderer.render("Todo", {todo: "write tests"}.to_json, nil)
     end
 
     assert_match(/after_render/, error.message)
@@ -69,7 +69,7 @@ class ExecJSRendererTest < ActiveSupport::TestCase
 
   test '.new accepts code:' do
     dummy_renderer = React::ServerRendering::ExecJSRenderer.new(code: DUMMY_IMPLEMENTATION)
-    result = dummy_renderer.render("Todo", {todo: "get a real job"}.to_json, {})
+    result = dummy_renderer.render("Todo", {todo: "get a real job"}.to_json, nil)
     assert_equal("renderToString was called", result)
   end
 end

--- a/test/server_rendered_html_test.rb
+++ b/test/server_rendered_html_test.rb
@@ -62,4 +62,11 @@ class ServerRenderedHtmlTest  < ActionDispatch::IntegrationTest
     # make sure that the layout is rendered with the component
     assert_match(/<title>Dummy<\/title>/, rendered_html)
   end
+
+  test 'exec js renderer' do
+    get '/server/exec_js_renderer'
+    assert_match("renderToString was called", response.body)
+    React::ServerRendering.renderer = React::ServerRendering::SprocketsRenderer
+    React::ServerRendering.reset_pool
+  end
 end


### PR DESCRIPTION
I'd like to use `ExecJSRenderer` for server side rendering as below.

```ruby
config.react.server_renderer = ExecJSRenderer
config.react.server_renderer_options[:code] = File.read "path/to/compiled_component.js"
```

However, it dose not work because

* `ExecJSRenderer#render`'s `prerender_options` expects a Hash , but actually it's `true` or `:static`.
* `ExecJSRenderer#render` dose not convert to JSON when `props` is not string.

This patch will resolve it.