### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ and pass [options](http://babeljs.io/docs/usage/options/) to the babel transpile
 
 ```ruby
 config.react.jsx_transform_options = {
-  blacklist: ['spec.functionName', 'validation.react'], # default options
+  blacklist: ['spec.functionName', 'validation.react', 'strict'], # default options
   optional: ["transformerName"],  # pass extra babel options
   whitelist: ["useStrict"] # even more options
 }


### PR DESCRIPTION
`React::JSX::BabelTransformer::DEFAULT_TRANSFORM_OPTIONS` is

```rb
{ blacklist: ['spec.functionName', 'validation.react', 'strict'] }
```

https://github.com/reactjs/react-rails/blob/290765a1ac14be3aea71d2d98c99760b4527a46e/lib/react/jsx/babel_transformer.rb#L6