### PR TITLE
Snake-Case key to Camel-Case key for props when server render

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ end
 - On MRI, you'll get a deadlock with `pool_size` > 1
 - If you're using JRuby, you can increase `pool_size` to have real multi-threaded rendering.
 
+You can configure camelize_props option and pass props with an underscored hash from rails but get a camelized hash in jsx :
+
+```ruby
+MyApp::Application.configure do
+  config.react.camelize_props = true #default false
+end
+```
+
 ### Rendering components instead of views
 
 Components can also be prerendered directly from a controller action with the custom `component` renderer. For example:

--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -9,6 +9,7 @@ module React
       include ActionView::Helpers::TagHelper
       include ActionView::Helpers::TextHelper
       attr_accessor :output_buffer
+      mattr_accessor :camelize_props_switch
 
       # ControllerLifecycle calls these hooks
       # You can use them in custom helper implementations
@@ -23,8 +24,8 @@ module React
       # on the client.
       def react_component(name, props = {}, options = {}, &block)
         options = {:tag => options} if options.is_a?(Symbol)
-        props = camelize_props_key(props)
-        
+        props = camelize_props_key(props) if camelize_props_switch
+
         prerender_options = options[:prerender]
         if prerender_options
           block = Proc.new{ concat React::ServerRendering.render(name, props, prerender_options) }

--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -23,7 +23,8 @@ module React
       # on the client.
       def react_component(name, props = {}, options = {}, &block)
         options = {:tag => options} if options.is_a?(Symbol)
-
+        props = camelize_props_key(props)
+        
         prerender_options = options[:prerender]
         if prerender_options
           block = Proc.new{ concat React::ServerRendering.render(name, props, prerender_options) }
@@ -40,6 +41,15 @@ module React
         html_options.except!(:tag, :prerender)
 
         content_tag(html_tag, '', html_options, &block)
+      end
+
+      private
+
+      def camelize_props_key(props)
+        return props unless props.is_a?(Hash)
+        props.inject({}) do |h, (k,v)|
+          h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v; h
+        end
       end
     end
   end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -9,6 +9,8 @@ module React
       config.react.addons = false
       config.react.jsx_transform_options = {}
       config.react.jsx_transformer_class = nil # defaults to BabelTransformer
+      config.react.camelize_props = false # pass in an underscored hash but get a camelized hash
+
       # Server rendering:
       config.react.server_renderer_pool_size  = 1   # increase if you're on JRuby
       config.react.server_renderer_timeout    = 20  # seconds
@@ -31,6 +33,7 @@ module React
 
         app.config.react.view_helper_implementation ||= React::Rails::ComponentMount
         React::Rails::ViewHelper.helper_implementation_class = app.config.react.view_helper_implementation
+        React::Rails::ComponentMount.camelize_props_switch = app.config.react.camelize_props
 
         ActiveSupport.on_load(:action_controller) do
           include ::React::Rails::ControllerLifecycle

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -26,7 +26,7 @@ module React
           end
 
         if !props.is_a?(String)
-          props = props.to_json
+          props = camelize_props_key(props).to_json
         end
 
         super(component_name, props, {render_function: react_render_method})
@@ -34,6 +34,18 @@ module React
 
       def after_render(component_name, props, prerender_options)
         @replay_console ? CONSOLE_REPLAY : ""
+      end
+
+      def camelize_props_key(props)
+        return props unless props.is_a?(Hash)
+        props.inject({}) do |h, (k,v)|
+          k = k.to_s.camelize(:lower)
+          if v.is_a?(Hash)
+            h[k] = camelize_props_key(v); h
+          else
+            h[k] = v; h
+          end
+        end
       end
 
       # Reimplement console methods for replaying on the client

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -39,12 +39,7 @@ module React
       def camelize_props_key(props)
         return props unless props.is_a?(Hash)
         props.inject({}) do |h, (k,v)|
-          k = k.to_s.camelize(:lower)
-          if v.is_a?(Hash)
-            h[k] = camelize_props_key(v); h
-          else
-            h[k] = v; h
-          end
+          h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v; h
         end
       end
 

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -26,7 +26,7 @@ module React
           end
 
         if !props.is_a?(String)
-          props = camelize_props_key(props).to_json
+          props = props.to_json
         end
 
         super(component_name, props, {render_function: react_render_method})
@@ -34,13 +34,6 @@ module React
 
       def after_render(component_name, props, prerender_options)
         @replay_console ? CONSOLE_REPLAY : ""
-      end
-
-      def camelize_props_key(props)
-        return props unless props.is_a?(Hash)
-        props.inject({}) do |h, (k,v)|
-          h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v; h
-        end
       end
 
       # Reimplement console methods for replaying on the client

--- a/test/react/rails/component_mount_test.rb
+++ b/test/react/rails/component_mount_test.rb
@@ -13,6 +13,16 @@ class ComponentMountTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test '#react_component accepts React props with camelize_props ' do
+    React::Rails::ComponentMount.camelize_props_switch = true
+    helper = React::Rails::ComponentMount.new
+    html = helper.react_component('Foo', {foo_bar: 'value'})
+    expected_props = %w(data-react-class="Foo" data-react-props="{&quot;fooBar&quot;:&quot;value&quot;}")
+    expected_props.each do |segment|
+      assert html.include?(segment)
+    end
+  end
+
   test '#react_component accepts jbuilder-based strings as properties' do
     jbuilder_json = Jbuilder.new do |json|
       json.bar 'value'


### PR DESCRIPTION
Camle-Case in es6.jsx:

```
static propTypes = {
		form: PropTypes.object,
		errorMessages: PropTypes.array,
		defaultFieldValues: PropTypes.object
	}
```

I must be camle-case  in Rails: 

```
props = {form: {action: "new"}, errorMessages: ["errors1, errors2"], defaultFieldValues:  {some: "value"}}
```


I think it's better in Rails:

```
props = {form: {action: "new"}, error_messages: ["errors1, errors2"], default_field_values: {some: "value"}}
```