### PR TITLE
Fix ECMAScript compilation

### DIFF
--- a/lib/react/rails/engine.rb
+++ b/lib/react/rails/engine.rb
@@ -4,7 +4,7 @@ module React
       initializer "react_rails.setup_engine", :group => :all do |app|
         sprockets_env = app.assets || Sprockets # Sprockets 3.x expects this in a different place
         if Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new("3.0.0")
-          sprockets_env.register_mime_type("application/jsx", extensions: [".jsx", ".js.jsx"])
+          sprockets_env.register_mime_type("application/jsx", extensions: [".jsx", ".js.jsx", ".es.jsx", ".es6.jsx"])
           sprockets_env.register_transformer("application/jsx", "application/javascript", React::JSX::Processor)
         else
           sprockets_env.register_engine(".jsx", React::JSX::Template)


### PR DESCRIPTION
Fixes https://github.com/reactjs/react-rails/issues/395 by adding `.es.jsx` and `.es6.jsx` extensions.

See https://github.com/reactjs/react-rails/issues/395#issuecomment-159058805 for details.