### PR TITLE
Include CHANGELOG in gem

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.files = Dir[
     'lib/**/*',
     'README.md',
+    'CHANGELOG.md',
     'LICENSE'
   ]
 


### PR DESCRIPTION
Help developers know what's new using `bundle open react-rails` etc after a `bundle update` instead of having to navigate to github.