### PR TITLE
Only require rails as a development dependency

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-script-source', '~>1.8'
   s.add_dependency 'connection_pool'
   s.add_dependency 'execjs'
-  s.add_dependency 'rails', '>= 3.2'
+  s.add_dependency 'railties', '>= 3.2'
   s.add_dependency 'tilt'
   s.add_dependency 'babel-transpiler', '>=0.7.0'
 

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'poltergeist', '>= 0.3.3'
   s.add_development_dependency 'test-unit', '~> 2.5'
   s.add_development_dependency 'turbolinks', '>= 2.0.0'
+  s.add_development_dependency 'rails', '>= 3.2'
 
   s.add_dependency 'coffee-script-source', '~>1.8'
   s.add_dependency 'connection_pool'


### PR DESCRIPTION
Requiring Rails as a runtime dependency causes issues if application does not use ActiveRecord.