### PR TITLE
Fix(SprocketsRenderer) support Sprockets::Manifest if assets were precompiled

### DIFF
--- a/lib/react/server_rendering/environment_container.rb
+++ b/lib/react/server_rendering/environment_container.rb
@@ -1,0 +1,18 @@
+module React
+  module ServerRendering
+    # Return asset contents by getting them from a Sprockets::Environment instance.
+    #
+    # This is good for Rails development but bad for production because:
+    # - It compiles the asset lazily, not ahead-of-time
+    # - Rails 5 / Sprockets 3 doesn't expose a Sprockets::Environment in production.
+    class EnvironmentContainer
+      def initialize
+        @environment = ::Rails.application.assets
+      end
+
+      def find_asset(logical_path)
+        @environment[logical_path].to_s
+      end
+    end
+  end
+end

--- a/lib/react/server_rendering/exec_js_renderer.rb
+++ b/lib/react/server_rendering/exec_js_renderer.rb
@@ -1,9 +1,9 @@
-# A bare-bones renderer for React.js + Exec.js
-# - Depends on global ReactDOMServer in the ExecJS context
-# - No Rails dependency
-# - No browser concerns
 module React
   module ServerRendering
+    # A bare-bones renderer for React.js + Exec.js
+    # - Depends on global ReactDOMServer in the ExecJS context
+    # - No Rails dependency
+    # - No browser concerns
     class ExecJSRenderer
       def initialize(options={})
         js_code = options[:code] || raise("Pass `code:` option to instantiate a JS context!")

--- a/lib/react/server_rendering/manifest_container.rb
+++ b/lib/react/server_rendering/manifest_container.rb
@@ -1,0 +1,19 @@
+module React
+  module ServerRendering
+    # Get asset content by reading the compiled file from disk using a Sprockets::Manifest.
+    #
+    # This is good for Rails production when assets are compiled to public/assets
+    # but sometimes, they're compiled to other directories (or other servers)
+    class ManifestContainer
+      def initialize
+        @manifest = ::Rails.application.assets_manifest
+      end
+
+      def find_asset(logical_path)
+        asset_path = manifest.assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
+        asset_full_path = ::Rails.root.join("public", @manifest.directory, asset_path)
+        File.read(asset_full_path)
+      end
+    end
+  end
+end

--- a/lib/react/server_rendering/manifest_container.rb
+++ b/lib/react/server_rendering/manifest_container.rb
@@ -10,7 +10,7 @@ module React
       end
 
       def find_asset(logical_path)
-        asset_path = manifest.assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
+        asset_path = @manifest.assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
         asset_full_path = ::Rails.root.join("public", @manifest.directory, asset_path)
         File.read(asset_full_path)
       end

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -15,7 +15,7 @@ module React
         js_code = CONSOLE_POLYFILL.dup
 
         filenames.each do |filename|
-          js_code << ::Rails.application.assets[filename].to_s
+          js_code << get_asset_content(filename)
         end
 
         super(options.merge(code: js_code))
@@ -38,6 +38,31 @@ module React
 
       def after_render(component_name, props, prerender_options)
         @replay_console ? CONSOLE_REPLAY : ""
+      end
+
+      # Given an asset name, return the fully-compiled body of that asset.
+      #
+      # Out of the box, it supports a Sprockets::Environment (application.assets)
+      # and a Sprockets::Manifest (application.assets_manifest), which covers the
+      # default Rails setups.
+      #
+      # Make a `server.js` which has `//= require react-server` and `//= require components`.
+      # Then add `server` to the precompile list, eg `Rails.application.config.assets.precompile += %w( server.js )`.
+      #
+      # In production, react-rails will use the precompiled file.
+      #
+      # TODO: what if the assets aren't on the local server (maybe they're on a CDN?)
+      # Can we check for asset_host configuration here?
+      def get_asset_content(asset_name)
+        if ::Rails.application.config.assets.compile
+          ::Rails.application.assets[asset_name].to_s
+        else
+          manifest = ::Rails.application.assets_manifest
+          # Find the corresponding compiled file:
+          asset_path = manifest.assets[asset_name] || raise("No compiled asset for #{asset_name}, was it precompiled?")
+          asset_full_path = ::Rails.root.join("public", manifest.directory, asset_path)
+          File.read(asset_full_path)
+        end
       end
     end
   end

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -42,18 +42,24 @@ module React
         @replay_console ? CONSOLE_REPLAY : ""
       end
 
-      # Given an asset name, return the fully-compiled body of that asset.
+      class << self
+        attr_accessor :asset_container_class
+      end
+
+      # Get an object which exposes assets by their logical path.
       #
       # Out of the box, it supports a Sprockets::Environment (application.assets)
       # and a Sprockets::Manifest (application.assets_manifest), which covers the
       # default Rails setups.
       #
-      # TODO: what if the assets aren't on the local server (maybe they're on a CDN?)
-      # Can we check for asset_host configuration here?
+      # You can provide a custom asset container
+      # with `React::ServerRendering::SprocketsRender.asset_container_class = MyAssetContainer`.
       #
       # @return [#find_asset(logical_path)] An object that returns asset contents by logical path
       def asset_container
-        @asset_container ||= if ::Rails.application.config.assets.compile
+        @asset_container ||= if self.class.asset_container_class.present?
+          self.class.asset_container_class.new
+        elsif ::Rails.application.config.assets.compile
           EnvironmentContainer.new
         else
           ManifestContainer.new

--- a/test/react/server_rendering/manifest_container_test.rb
+++ b/test/react/server_rendering/manifest_container_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class ManifestContainerTest < ActiveSupport::TestCase
+  def setup
+    precompile_assets
+
+    # Make a new manifest since assets weren't compiled before
+    config = Rails.application.config
+    path = File.join(config.paths['public'].first, config.assets.prefix)
+    new_manifest = Sprockets::Manifest.new(Rails.application.assets, path, config.assets.manifest)
+    Rails.application.assets_manifest = new_manifest
+
+    @manifest_container = React::ServerRendering::ManifestContainer.new
+  end
+
+  def teardown
+    clear_precompiled_assets
+  end
+
+  def test_find_asset_gets_asset_contents
+    application_js_content = @manifest_container.find_asset("application.js")
+    assert(application_js_content.length > 50000, "It's the compiled file")
+  end
+end

--- a/test/react/server_rendering/manifest_container_test.rb
+++ b/test/react/server_rendering/manifest_container_test.rb
@@ -1,24 +1,28 @@
 require "test_helper"
 
-class ManifestContainerTest < ActiveSupport::TestCase
-  def setup
-    precompile_assets
+# Rails 3.x doesn't have `application.assets_manifest=`
+# I don't think we have to support Rails 3 + Sprockets 3 anyways!
+if Rails::VERSION::MAJOR > 3
+  class ManifestContainerTest < ActiveSupport::TestCase
+    def setup
+      precompile_assets
 
-    # Make a new manifest since assets weren't compiled before
-    config = Rails.application.config
-    path = File.join(config.paths['public'].first, config.assets.prefix)
-    new_manifest = Sprockets::Manifest.new(Rails.application.assets, path, config.assets.manifest)
-    Rails.application.assets_manifest = new_manifest
+      # Make a new manifest since assets weren't compiled before
+      config = Rails.application.config
+      path = File.join(config.paths['public'].first, config.assets.prefix)
+      new_manifest = Sprockets::Manifest.new(Rails.application.assets, path)
+      Rails.application.assets_manifest = new_manifest
 
-    @manifest_container = React::ServerRendering::ManifestContainer.new
-  end
+      @manifest_container = React::ServerRendering::ManifestContainer.new
+    end
 
-  def teardown
-    clear_precompiled_assets
-  end
+    def teardown
+      clear_precompiled_assets
+    end
 
-  def test_find_asset_gets_asset_contents
-    application_js_content = @manifest_container.find_asset("application.js")
-    assert(application_js_content.length > 50000, "It's the compiled file")
+    def test_find_asset_gets_asset_contents
+      application_js_content = @manifest_container.find_asset("application.js")
+      assert(application_js_content.length > 50000, "It's the compiled file")
+    end
   end
 end

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -26,12 +26,9 @@ class ReactTest < ActionDispatch::IntegrationTest
 
   test 'precompiling assets works' do
     begin
-      ENV['RAILS_GROUPS'] = 'assets' # required for Rails 3.2
-      Dummy::Application.load_tasks
-      Rake::Task['assets:precompile'].invoke
-      FileUtils.rm_r(File.expand_path("../dummy/public/assets", __FILE__))
+      precompile_assets
     ensure
-      ENV.delete('RAILS_GROUPS')
+      clear_precompiled_assets
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,18 @@ def manually_expire_asset(asset_name)
   def asset.fresh?(env); false; end
 end
 
+def precompile_assets
+  ENV['RAILS_GROUPS'] = 'assets' # required for Rails 3.2
+  Dummy::Application.load_tasks
+  Rake::Task['assets:precompile'].reenable
+  Rake::Task['assets:precompile'].invoke
+end
+
+def clear_precompiled_assets
+  FileUtils.rm_r(File.expand_path("../dummy/public/assets", __FILE__))
+  ENV.delete('RAILS_GROUPS')
+end
+
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 


### PR DESCRIPTION
Previously, `SprocketsRenderer` would live-compile assets, even in production. However, this is _impossible_ in Rails 5 (not just improper) because there _is no_ `Sprockets::Environment` at `Rails.application.assets`. 

Instead, there is a `Sprockets::Manifest` at `Rails.application.assets_manifest` which tells where each file's compiled counterpart is. 

So, if the Sprockets::Environment isn't available, use the manifest. 

## TODO 

- [x] Prefer the Manifest over the Environment (to avoid double-compiling assets)
- [x] Somehow, handle cases where assets are pushed to a CDN, not the local Rails server 
  - [x] ~~Check for `asset_host` config?~~, no because that doesn't necessarily mean the files are remote
  - [x] Extract `get_asset_content` to classes
  - [x] Accept a custom AssetContainer 
