### PR TITLE
BabelTransformer options on a per-file basis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Breaking Changes
 
+- The `Transformer#transform` signature has changed from `transform(code)` to `transform(code, options = {})`.
+
 #### New Features
 
 - When using the (default) `BabelTransformer`, `config.react.jsx_transform_options` can accept a lambda, proc, or anything that responds to `call` and returns a hash. This is useful if you have Babel transformation options that need to be uniq per file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 #### New Features
 
+- When using the (default) `BabelTransformer`, `config.react.jsx_transform_options` can accept a lambda, proc, or anything that responds to `call` and returns a hash. This is useful if you have Babel transformation options that need to be uniq per file.
+
 #### Deprecation
 
 #### Bug Fixes
 
-## 1.8.0 (June 29, 2016)
+- Add CHANGELOG to gem bundle #471
+- Use `window.attachEvent` to support IE8 without jQuery 😬#446
 
 #### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Breaking Changes
 
-- The `Transformer#transform` signature has changed from `transform(code)` to `transform(code, options = {})`.
+- The `Transformer#transform` signature has changed from `transform(code)` to `transform(code, local_options = {})`.
 
 #### New Features
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ config.react.jsx_transform_options = {
   whitelist: ["useStrict"] # even more options
 }
 ```
+
+If you need to make specializations on a per-file basis, the options can accept a lambda, proc, or anything that responds to `call` and returns a hash of Babel options. The argument yielded is the raw input that the `JSX::Processor` received from `Sprockets`.
+
+```ruby
+config.react.jsx_transorm_options = ->(input) {
+  amd: true,
+  moduleId: input[:name],
+}
+```
+
 Under the hood, `react-rails` uses [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler), for transformation.
 
 ### Rendering & mounting

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -13,7 +13,7 @@ module React
     # You can assign `config.react.jsx_transformer_class = `
     # to provide your own transformer. It must implement:
     # - #initialize(options)
-    # - #transform(code) => new code
+    # - #transform(code, local_options = {}) => new code
     #
     # If you want to configure per-file transformation options with a proc, you may
     # accept an optional second parameter
@@ -23,13 +23,10 @@ module React
     def self.transform(code, input = {})
       self.transformer ||= transformer_class.new(transform_options)
 
-      if self.transformer.method(:transform).arity == 1
-        self.transformer.transform(code)
-      else
-        local_options = self.transform_options
-        local_options = local_options.call(input) if local_options.respond_to?(:call)
-        self.transformer.transform(code, local_options)
-      end
+      local_options = self.transform_options
+      local_options = local_options.call(input) if local_options.respond_to?(:call)
+
+      self.transformer.transform(code, local_options)
     end
   end
 end

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -15,19 +15,21 @@ module React
     # - #initialize(options)
     # - #transform(code) => new code
     #
-    # If you want to configure per-file transformation options, you may
-    # optionally implement:
-    # - #transform_with_proc_options(input) => new code
+    # If you want to configure per-file transformation options with a proc, you may
+    # accept an optional second parameter
+    # - #transform(code, local_options = {}) => new code
     self.transformer_class = DEFAULT_TRANSFORMER
 
-    def self.transform(code)
+    def self.transform(code, input = {})
       self.transformer ||= transformer_class.new(transform_options)
-      self.transformer.transform(code)
-    end
 
-    def self.transform_with_proc_options(input)
-      self.transformer ||= transformer_class.new(transform_options)
-      self.transformer.transform_with_proc_options(input)
+      if self.transformer.method(:transform).arity == 1
+        self.transformer.transform(code)
+      else
+        local_options = self.transform_options
+        local_options = local_options.call(input) if local_options.respond_to?(:call)
+        self.transformer.transform(code, local_options)
+      end
     end
   end
 end

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -14,11 +14,20 @@ module React
     # to provide your own transformer. It must implement:
     # - #initialize(options)
     # - #transform(code) => new code
+    #
+    # If you want to configure per-file transformation options, you may
+    # optionally implement:
+    # - #transform_with_proc_options(input) => new code
     self.transformer_class = DEFAULT_TRANSFORMER
 
     def self.transform(code)
       self.transformer ||= transformer_class.new(transform_options)
       self.transformer.transform(code)
+    end
+
+    def self.transform_with_proc_options(input)
+      self.transformer ||= transformer_class.new(transform_options)
+      self.transformer.transform_with_proc_options(input)
     end
   end
 end

--- a/lib/react/jsx/babel_transformer.rb
+++ b/lib/react/jsx/babel_transformer.rb
@@ -3,16 +3,9 @@ module React
   module JSX
     # A {React::JSX}-compliant transformer which uses `Babel::Transpiler` to transform JSX.
     class BabelTransformer
-      DEPRECATED_OPTIONS = [:harmony, :strip_types, :asset_path]
       DEFAULT_TRANSFORM_OPTIONS = { blacklist: ['spec.functionName', 'validation.react', 'strict'] }
 
-      def initialize(options)
-        return unless options.is_a?(Hash)
-
-        if (options.keys & DEPRECATED_OPTIONS).any?
-          ActiveSupport::Deprecation.warn("Setting config.react.jsx_transform_options for :harmony, :strip_types, and :asset_path keys is now deprecated and has no effect with the default Babel Transformer."+
-          "Please use new Babel Transformer options :whitelist, :plugin instead.")
-        end
+      def initialize(noop)
       end
 
       def transform(code, local_options = {})

--- a/lib/react/jsx/babel_transformer.rb
+++ b/lib/react/jsx/babel_transformer.rb
@@ -5,7 +5,10 @@ module React
     class BabelTransformer
       DEPRECATED_OPTIONS = [:harmony, :strip_types, :asset_path]
       DEFAULT_TRANSFORM_OPTIONS = { blacklist: ['spec.functionName', 'validation.react', 'strict'] }
+
       def initialize(options)
+        return @transform_options_proc = options if options.respond_to?(:call)
+
         if (options.keys & DEPRECATED_OPTIONS).any?
           ActiveSupport::Deprecation.warn("Setting config.react.jsx_transform_options for :harmony, :strip_types, and :asset_path keys is now deprecated and has no effect with the default Babel Transformer."+
                                               "Please use new Babel Transformer options :whitelist, :plugin instead.")
@@ -16,6 +19,11 @@ module React
 
       def transform(code)
         Babel::Transpiler.transform(code, @transform_options)['code']
+      end
+
+      def transform_with_proc_options(input)
+        options = DEFAULT_TRANSFORM_OPTIONS.merge(@transform_options_proc.call(input))
+        Babel::Transpiler.transform(input[:data], options)['code']
       end
     end
   end

--- a/lib/react/jsx/babel_transformer.rb
+++ b/lib/react/jsx/babel_transformer.rb
@@ -7,23 +7,17 @@ module React
       DEFAULT_TRANSFORM_OPTIONS = { blacklist: ['spec.functionName', 'validation.react', 'strict'] }
 
       def initialize(options)
-        return @transform_options_proc = options if options.respond_to?(:call)
+        return unless options.is_a?(Hash)
 
         if (options.keys & DEPRECATED_OPTIONS).any?
           ActiveSupport::Deprecation.warn("Setting config.react.jsx_transform_options for :harmony, :strip_types, and :asset_path keys is now deprecated and has no effect with the default Babel Transformer."+
-                                              "Please use new Babel Transformer options :whitelist, :plugin instead.")
+          "Please use new Babel Transformer options :whitelist, :plugin instead.")
         end
-
-        @transform_options = DEFAULT_TRANSFORM_OPTIONS.merge(options)
       end
 
-      def transform(code)
-        Babel::Transpiler.transform(code, @transform_options)['code']
-      end
-
-      def transform_with_proc_options(input)
-        options = DEFAULT_TRANSFORM_OPTIONS.merge(@transform_options_proc.call(input))
-        Babel::Transpiler.transform(input[:data], options)['code']
+      def transform(code, local_options = {})
+        options = DEFAULT_TRANSFORM_OPTIONS.merge(local_options)
+        Babel::Transpiler.transform(code, options)['code']
       end
     end
   end

--- a/lib/react/jsx/jsx_transformer.rb
+++ b/lib/react/jsx/jsx_transformer.rb
@@ -19,7 +19,7 @@ module React
       end
 
 
-      def transform(code)
+      def transform(code, _local_options = {})
         result = @context.call('JSXTransformer.transform', code, @transform_options)
         result["code"]
       end

--- a/lib/react/jsx/processor.rb
+++ b/lib/react/jsx/processor.rb
@@ -3,11 +3,7 @@ module React
     # A Sprockets 3+-compliant processor
     class Processor
       def self.call(input)
-        if JSX::transform_options.respond_to?(:call)
-          JSX::transform_with_proc_options(input)
-        else
-          JSX::transform(input[:data])
-        end
+        JSX::transform(input[:data], input)
       end
     end
   end

--- a/lib/react/jsx/processor.rb
+++ b/lib/react/jsx/processor.rb
@@ -3,7 +3,11 @@ module React
     # A Sprockets 3+-compliant processor
     class Processor
       def self.call(input)
-        JSX::transform(input[:data])
+        if JSX::transform_options.respond_to?(:call)
+          JSX::transform_with_proc_options(input)
+        else
+          JSX::transform(input[:data])
+        end
       end
     end
   end

--- a/test/dummy/app/assets/javascripts/amd_example.jsx
+++ b/test/dummy/app/assets/javascripts/amd_example.jsx
@@ -1,2 +1,5 @@
-const add = (a, b) => (a + b)
-export default add
+import multiply from "multiply"
+
+const square = (a) => multiply(a, a)
+
+export default square

--- a/test/dummy/app/assets/javascripts/amd_example.jsx
+++ b/test/dummy/app/assets/javascripts/amd_example.jsx
@@ -1,0 +1,2 @@
+const add = (a, b) => (a + b)
+export default add

--- a/test/react/jsx_test.rb
+++ b/test/react/jsx_test.rb
@@ -76,4 +76,18 @@ when_sprockets_available do
       assert_equal expectation.gsub(/\s/, ''), javascript.gsub(/\s/, '')
     end
   end
+
+  def test_babel_transformer_can_provide_per_file_options_with_a_proc
+    React::JSX.transform_options = ->(input) do
+      {
+        moduleId: "this_was_not_possible_before/#{input[:name]}",
+        moduleRoot: nil,
+        modules: "amd",
+      }
+    end
+
+    get '/assets/amd_example.js'
+    assert_response :success
+    assert @response.body.include?(%q[define("this_was_not_possible_before/amd_example"])
+  end
 end

--- a/test/react/jsx_test.rb
+++ b/test/react/jsx_test.rb
@@ -77,19 +77,24 @@ when_sprockets_available do
     end
   end
 
-  class AmdOptions
-    def self.call(input)
-      {
-        modules: "amd",
-        moduleId: "this_was_not_possible_before/#{input[:name]}",
-      }
-    end
-  end
-
   def test_babel_transformer_can_provide_per_file_options_with_a_proc
-    React::JSX.transform_options = AmdOptions
+    React::JSX.transform_options = amd_options_with_sprockets_version_awareness
     get '/assets/amd_example.js'
     assert_response :success
     assert response.body.include?('define("this_was_not_possible_before/amd_example"'), response.body
   end
+  
+  def amd_options_with_sprockets_version_awareness
+    if Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new("3.0.0")
+      lambda do |input|
+        { modules: "amd", moduleId: "this_was_not_possible_before/#{input[:name]}" }
+      end
+    else
+      # TODO: Is this even posssible before Sprockets 3? Sorry Sprockets 2 users...
+      lambda do |input|
+        { modules: "amd", moduleId: "this_was_not_possible_before/amd_example" }
+      end
+    end
+  end
+
 end

--- a/test/react/jsx_test.rb
+++ b/test/react/jsx_test.rb
@@ -21,7 +21,7 @@ eos
 
 class NullTransformer
   def initialize(options={}); end
-  def transform(code)
+  def transform(code, options = {})
     "TRANSFORMED CODE!;\n"
   end
 end
@@ -83,7 +83,7 @@ when_sprockets_available do
     assert_response :success
     assert response.body.include?('define("this_was_not_possible_before/amd_example"'), response.body
   end
-  
+
   def amd_options_with_sprockets_version_awareness
     if Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new("3.0.0")
       lambda do |input|

--- a/test/react/jsx_test.rb
+++ b/test/react/jsx_test.rb
@@ -90,6 +90,6 @@ when_sprockets_available do
     React::JSX.transform_options = AmdOptions
     get '/assets/amd_example.js'
     assert_response :success
-    assert response.body.include?('define("this_was_not_possible_before/amd_example"')
+    assert response.body.include?('define("this_was_not_possible_before/amd_example"'), response.body
   end
 end

--- a/test/react/jsx_test.rb
+++ b/test/react/jsx_test.rb
@@ -77,17 +77,19 @@ when_sprockets_available do
     end
   end
 
-  def test_babel_transformer_can_provide_per_file_options_with_a_proc
-    React::JSX.transform_options = ->(input) do
+  class AmdOptions
+    def self.call(input)
       {
-        moduleId: "this_was_not_possible_before/#{input[:name]}",
-        moduleRoot: nil,
         modules: "amd",
+        moduleId: "this_was_not_possible_before/#{input[:name]}",
       }
     end
+  end
 
+  def test_babel_transformer_can_provide_per_file_options_with_a_proc
+    React::JSX.transform_options = AmdOptions
     get '/assets/amd_example.js'
     assert_response :success
-    assert @response.body.include?(%q[define("this_was_not_possible_before/amd_example"])
+    assert response.body.include?('define("this_was_not_possible_before/amd_example"')
   end
 end


### PR DESCRIPTION
### Motivation

While trying to bring some organization to client-side code we were exploring the usage of defining AMD modules, and requiring them with a tool such as [almond](https://github.com/jrburke/almond). The Babel transpiler has the ability to generate AMD modules baked in, but the we aren't able to pass the needed `moduleId` option on a per file basis.

### Solution

Provide a way to make per-file configurations by using a lambda, proc, or anything that responds to `call` and returns a `Hash` as the `jsx_transform_options`.

### Sidenote

This could be particularly useful for those who want to author their code with ES6 modules syntax. I've noticed in the issues that several users are reaching for `browserify-rails` to solve this problem. The
dependency on npm and divide between npm and sprockets leads to a lot of questions, configration, and troubleshooting. If the end-goal is to have ES6 syntax, almond and some AMD configuration will solve that problem without having to add another dependency.