### PR TITLE
Support controller callbacks for Rails 3..5

### DIFF
--- a/lib/react/rails/controller_lifecycle.rb
+++ b/lib/react/rails/controller_lifecycle.rb
@@ -4,9 +4,11 @@ module React
       extend ActiveSupport::Concern
 
       included do
-        # use old names to support Rails 3
-        before_filter :setup_react_component_helper
-        after_filter :teardown_react_component_helper
+        # use both names to support Rails 3..5
+        before_action_with_fallback = begin method(:before_action); rescue method(:before_filter); end
+        after_action_with_fallback = begin method(:after_action); rescue method(:after_filter); end
+        before_action_with_fallback.call :setup_react_component_helper
+        after_action_with_fallback.call :teardown_react_component_helper
         attr_reader :__react_component_helper
       end
 

--- a/lib/react/rails/controller_lifecycle.rb
+++ b/lib/react/rails/controller_lifecycle.rb
@@ -5,10 +5,10 @@ module React
 
       included do
         # use both names to support Rails 3..5
-        before_action_with_fallback = begin method(:before_action); rescue method(:before_filter); end
-        after_action_with_fallback = begin method(:after_action); rescue method(:after_filter); end
-        before_action_with_fallback.call :setup_react_component_helper
-        after_action_with_fallback.call :teardown_react_component_helper
+        before_action_with_fallback = respond_to?(:before_action) ? :before_action : :before_filter
+        after_action_with_fallback = respond_to?(:after_action) ? :after_action : :after_filter
+        public_send(before_action_with_fallback, :setup_react_component_helper)
+        public_send(after_action_with_fallback, :teardown_react_component_helper)
         attr_reader :__react_component_helper
       end
 


### PR DESCRIPTION
`before_filter` is deprecated in Rails 5 and will disappear in 5.1

This change begins using `before_action`, with a fallback to `before_filter` if `before_action` is not available.

closes #404