### PR TITLE
Remove data-react-props attribute after mounting component

### DIFF
--- a/lib/assets/javascripts/react_ujs.js.erb
+++ b/lib/assets/javascripts/react_ujs.js.erb
@@ -57,6 +57,8 @@
         var renderer = (typeof ReactDOM == "object") ? ReactDOM : React;
 
         renderer.render(React.createElement(constructor, props), node);
+
+        node.removeAttribute(window.ReactRailsUJS.PROPS_ATTR);
       }
     },
 


### PR DESCRIPTION
This feature makes not to expose props data to html by removing 'data-react-props' attribute after mounting component.

I think it is good idea better than to expose all props data.