### PR TITLE
make SprocketsRenderer more extendable

### DIFF
--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -11,34 +11,53 @@ module React
 
       def initialize(options={})
         @replay_console = options.fetch(:replay_console, true)
-        filenames = options.fetch(:files, ["react-server.js", "components.js"])
         js_code = CONSOLE_POLYFILL.dup
-
-        filenames.each do |filename|
-          js_code << ::Rails.application.assets[filename].to_s
-        end
-
+        js_code << load_asset_files(options)
         super(options.merge(code: js_code))
       end
 
+      # pass prerender: :static to use renderToStaticMarkup
       def render(component_name, props, prerender_options)
-        # pass prerender: :static to use renderToStaticMarkup
+        if !props.is_a?(String)
+          props = props.to_json
+        end
+
+        super(component_name, props, prerender_options_with_defaults(prerender_options))
+      end
+
+      def after_render(component_name, props, prerender_options)
+        @replay_console ? CONSOLE_REPLAY : ""
+      end
+
+      private
+
+      def prerender_options_with_defaults(prerender_options)
         react_render_method = if prerender_options == :static
             "renderToStaticMarkup"
           else
             "renderToString"
           end
 
-        if !props.is_a?(String)
-          props = props.to_json
+        render_function_option = {
+          render_function: react_render_method
+        }
+
+        if prerender_options.respond_to?(:merge)
+          prerender_options.merge(render_function_option)
+        else
+          render_function_option
         end
-
-        super(component_name, props, {render_function: react_render_method})
       end
 
-      def after_render(component_name, props, prerender_options)
-        @replay_console ? CONSOLE_REPLAY : ""
+      def load_asset_files(options)
+        "".tap do |js_code|
+          filenames = options.fetch(:files, ["react-server.js", "components.js"])
+          filenames.each do |filename|
+            js_code << ::Rails.application.assets[filename].to_s
+          end
+        end
       end
+
     end
   end
 end


### PR DESCRIPTION
* extract asset resolution logic into a overridable method: load_asset_files
* allow prerender_options to come in as a hash already from a subclass and merge in the render_function option

The background for this is that I'm using a custom server renderer subclass that uses different asset fetching logic and also uses a hash as prerender options to hold custom options to hold Flux store initialization javascript. Without this change, I had to subclass ExecJsRenderer and duplicate the code already present in SprocketsRenderer, e.g. console polyfiling and the props.to_json. With this change I can just override the asset loading and rely on this base class for everything else.