### PR TITLE
add ability to pass in a custom selector function to mountComponents

### DIFF
--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -27,7 +27,8 @@
           parent = searchSelector;
           break;
         case 'string':
-          selector = searchSelector + ' [' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']';
+          selector = searchSelector + '[' + window.ReactRailsUJS.CLASS_NAME_ATTR + '], ' +
+                     searchSelector + ' [' + window.ReactRailsUJS.CLASS_NAME_ATTR + ']';
           parent = document;
           break
         default:

--- a/test/dummy/app/views/pages/show.html.erb
+++ b/test/dummy/app/views/pages/show.html.erb
@@ -4,11 +4,14 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'HelloMessage', :name => @name %>
+  <%= react_component 'HelloMessage', { :name => @name }, { :id => 'component' } %>
 </div>
 
 <a href='#' onClick="ReactRailsUJS.unmountComponents('#component-parent')">Unmount at selector #component-parent</a>
 <a href='#' onClick="ReactRailsUJS.mountComponents('#component-parent')">Mount at selector #component-parent</a>
+
+<a href='#' onClick="ReactRailsUJS.unmountComponents('#component')">Unmount at selector #component</a>
+<a href='#' onClick="ReactRailsUJS.mountComponents('#component')">Mount at selector #component</a>
 
 <a href='#' onClick="ReactRailsUJS.unmountComponents(document.querySelector('#component-parent'))">Unmount at node #component-parent</a>
 <a href='#' onClick="ReactRailsUJS.mountComponents(document.querySelector('#component-parent'))">Mount at node #component-parent</a>

--- a/test/dummy/app/views/pages/show.html.erb
+++ b/test/dummy/app/views/pages/show.html.erb
@@ -3,12 +3,12 @@
   <li><%= link_to 'Bob', page_path(:id => 1) %></li>
 </ul>
 
-<div id='test-component'>
+<div id='component-parent'>
   <%= react_component 'HelloMessage', :name => @name %>
 </div>
 
-<a href='#' onClick="ReactRailsUJS.unmountComponents('#test-component')">Unmount at selector #test-component</a>
-<a href='#' onClick="ReactRailsUJS.mountComponents('#test-component')">Mount at selector #test-component</a>
+<a href='#' onClick="ReactRailsUJS.unmountComponents('#component-parent')">Unmount at selector #component-parent</a>
+<a href='#' onClick="ReactRailsUJS.mountComponents('#component-parent')">Mount at selector #component-parent</a>
 
-<a href='#' onClick="ReactRailsUJS.unmountComponents(document.querySelector('#test-component'))">Unmount at node #test-component</a>
-<a href='#' onClick="ReactRailsUJS.mountComponents(document.querySelector('#test-component'))">Mount at node #test-component</a>
+<a href='#' onClick="ReactRailsUJS.unmountComponents(document.querySelector('#component-parent'))">Unmount at node #component-parent</a>
+<a href='#' onClick="ReactRailsUJS.mountComponents(document.querySelector('#component-parent'))">Mount at node #component-parent</a>

--- a/test/react/rails/react_rails_ujs_test.rb
+++ b/test/react/rails/react_rails_ujs_test.rb
@@ -91,14 +91,14 @@ class ReactRailsUJSTest < ActionDispatch::IntegrationTest
     assert page.has_content?('Hello Bob')
   end
 
-  test 'react_ujs can unmount/mount using a selector reference' do
+  test 'react_ujs can unmount/mount using a selector reference for a component parent' do
     visit '/pages/1'
     assert page.has_content?('Hello Bob')
 
-    page.click_link "Unmount at selector #test-component"
+    page.click_link "Unmount at selector #component-parent"
     assert page.has_no_content?('Hello Bob')
 
-    page.click_link "Mount at selector #test-component"
+    page.click_link "Mount at selector #component-parent"
     assert page.has_content?('Hello Bob')
   end
 
@@ -106,10 +106,10 @@ class ReactRailsUJSTest < ActionDispatch::IntegrationTest
     visit '/pages/1'
     assert page.has_content?('Hello Bob')
 
-    page.click_link "Unmount at node #test-component"
+    page.click_link "Unmount at node #component-parent"
     assert page.has_no_content?('Hello Bob')
 
-    page.click_link "Mount at node #test-component"
+    page.click_link "Mount at node #component-parent"
     assert page.has_content?('Hello Bob')
   end
 

--- a/test/react/rails/react_rails_ujs_test.rb
+++ b/test/react/rails/react_rails_ujs_test.rb
@@ -102,6 +102,17 @@ class ReactRailsUJSTest < ActionDispatch::IntegrationTest
     assert page.has_content?('Hello Bob')
   end
 
+  test 'react_ujs can unmount/mount using a selector reference for the component' do
+    visit '/pages/1'
+    assert page.has_content?('Hello Bob')
+
+    page.click_link "Unmount at selector #component"
+    assert page.has_no_content?('Hello Bob')
+
+    page.click_link "Mount at selector #component"
+    assert page.has_content?('Hello Bob')
+  end
+
   test 'react_ujs can unmount/mount using a dom node context' do
     visit '/pages/1'
     assert page.has_content?('Hello Bob')


### PR DESCRIPTION
* this is to support the case where you want to mount or unmount a single component
  with a known ID that is a sibling of one or more components that you don't want to affect
* currently, if you pass in a parent element to use a scope, it will mount/unmount
  all components underneath
* you also can't pass in the known ID of a mounted component because the selector
  it constructs assumes the react element is a child


The context for this change is we have a custom view helper that goes through a bunch of hoops to properly render React components used in older Rails pages that replace portions of their page with ajax and the Protoype/jQuery helpers. We need a way to mount components that are inserted into the page this way and we have the element's IDs. Unfortunately, none of the existing parameter options in mountComponents will allow us to mount a single element with a known ID.

We're currently using this hack to make it work:
`ReactRailsUJS.mountComponents('#knownID, html >');`

Due to the way it builds the selector string, this purposely creates a non-matching selector for the second bit, leaving only the ID selector to match. But this is britle and relies on the impl of ReactRailsUJS not changing. I'd love to get rid of this hack and use this impl instead.