### PR TITLE
Refactor UJS, support Turbolinks 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,9 @@ matrix:
       rvm: 2.1
   allow_failures:
     - rvm: jruby-9.0.1.0
+
+before_install:
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -4,4 +4,7 @@ source "http://rubygems.org"
 
 gem "rails", "~> 4.1.10"
 
+# Just to make sure we support old Turbolinks:
+gem "turbolinks", "~> 2.3.0"
+
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,5 +3,6 @@
 source "http://rubygems.org"
 
 gem "rails", "~> 4.2.1"
+gem "turbolinks", "~> 2.5.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,6 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 5.0.0.beta1"
+gem "rails", "~> 5.0.0.beta2"
+gem "turbolinks", "~> 5.0.0.beta"
 
 gemspec :path => "../"

--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -1,0 +1,4 @@
+//= require react_ujs_mount
+//= require react_ujs_turbolinks_classic
+//= require react_ujs_native
+//= require react_ujs_event_setup

--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -1,4 +1,6 @@
 //= require react_ujs_mount
+//= require react_ujs_turbolinks
 //= require react_ujs_turbolinks_classic
+//= require react_ujs_turbolinks_classic_deprecated
 //= require react_ujs_native
 //= require react_ujs_event_setup

--- a/lib/assets/javascripts/react_ujs_event_setup.js
+++ b/lib/assets/javascripts/react_ujs_event_setup.js
@@ -1,6 +1,27 @@
-// Detect which kind of events to set up:
-if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
-  ReactRailsUJS.TurbolinksClassic.setup();
-} else {
-  ReactRailsUJS.Native.setup();
-}
+;(function(document, window) {
+  // jQuery is optional. Use it to support legacy browsers.
+  var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+  if ($) {
+    ReactRailsUJS.handleEvent = function(eventName, callback) {
+      $(document).on(eventName, callback);
+    };
+  } else {
+    ReactRailsUJS.handleEvent = function(eventName, callback) {
+      document.addEventListener(eventName, callback);
+    };
+  }
+  // Detect which kind of events to set up:
+  if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+    if (typeof Turbolinks.EVENTS !== 'undefined') {
+      // Turbolinks.EVENTS is in classic version 2.4.0+
+      ReactRailsUJS.TurbolinksClassic.setup();
+    } else if (typeof Turbolinks.controller !== "undefined") {
+      // Turbolinks.controller is in version 5+
+      ReactRailsUJS.Turbolinks.setup();
+    } else {
+      ReactRailsUJS.TurbolinksClassicDeprecated.setup();
+    }
+  } else {
+    ReactRailsUJS.Native.setup();
+  }
+})(document, window);

--- a/lib/assets/javascripts/react_ujs_event_setup.js
+++ b/lib/assets/javascripts/react_ujs_event_setup.js
@@ -1,8 +1,6 @@
-// TODO give this file a good name
-
 // Detect which kind of events to set up:
 if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
   ReactRailsUJS.TurbolinksClassic.setup();
 } else {
-  ReactRailsUJS.Native.setup()
+  ReactRailsUJS.Native.setup();
 }

--- a/lib/assets/javascripts/react_ujs_event_setup.js
+++ b/lib/assets/javascripts/react_ujs_event_setup.js
@@ -1,0 +1,8 @@
+// TODO give this file a good name
+
+// Detect which kind of events to set up:
+if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+  ReactRailsUJS.TurbolinksClassic.setup();
+} else {
+  ReactRailsUJS.Native.setup()
+}

--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -1,15 +1,16 @@
-/*globals React, Turbolinks*/
-
-// Unobtrusive scripting adapter for React
 ;(function(document, window) {
   // jQuery is optional. Use it to support legacy browsers.
   var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
 
-  // create the  namespace
   window.ReactRailsUJS = {
+    // This attribute holds the name of component which should be mounted
+    // example: `data-react-class="MyApp.Items.EditForm"`
     CLASS_NAME_ATTR: 'data-react-class',
+
+    // This attribute holds JSON stringified props for initializing the component
+    // example: `data-react-props="{\"item\": { \"id\": 1, \"name\": \"My Item\"} }"`
     PROPS_ATTR: 'data-react-props',
-    RAILS_ENV_DEVELOPMENT: <%= Rails.env == "development" %>,
+
     // helper method for the mount and unmount methods to find the
     // `data-react-class` DOM elements
     findDOMNodes: function(searchSelector) {
@@ -40,6 +41,8 @@
       }
     },
 
+    // Within `searchSelector`, find nodes which should have React components
+    // inside them, and mount them with their props.
     mountComponents: function(searchSelector) {
       var nodes = window.ReactRailsUJS.findDOMNodes(searchSelector);
 
@@ -60,6 +63,8 @@
       }
     },
 
+    // Within `searchSelector`, find nodes which have React components
+    // inside them, and unmount those components.
     unmountComponents: function(searchSelector) {
       var nodes = window.ReactRailsUJS.findDOMNodes(searchSelector);
 
@@ -72,51 +77,4 @@
       }
     }
   };
-
-  // functions not exposed publicly
-  function handleTurbolinksEvents () {
-    var handleEvent;
-    var unmountEvent;
-
-    if ($) {
-      handleEvent = function(eventName, callback) {
-        $(document).on(eventName, callback);
-      };
-
-    } else {
-      handleEvent = function(eventName, callback) {
-        document.addEventListener(eventName, callback);
-      };
-    }
-
-    if (Turbolinks.EVENTS) {
-      unmountEvent = Turbolinks.EVENTS.BEFORE_UNLOAD;
-    } else {
-      unmountEvent = 'page:receive';
-      Turbolinks.pagesCached(0);
-
-      if (window.ReactRailsUJS.RAILS_ENV_DEVELOPMENT) {
-        console.warn('The Turbolinks cache has been disabled (Turbolinks >= 2.4.0 is recommended). See https://github.com/reactjs/react-rails/issues/87 for more information.');
-      }
-    }
-    handleEvent('page:change', function() {window.ReactRailsUJS.mountComponents()});
-    handleEvent(unmountEvent, function() {window.ReactRailsUJS.unmountComponents()});
-  }
-
-  function handleNativeEvents() {
-    if ($) {
-      $(function() {window.ReactRailsUJS.mountComponents()});
-    } else if ('addEventListener' in window) {
-      document.addEventListener('DOMContentLoaded', function() {window.ReactRailsUJS.mountComponents()});
-    } else {
-      // add support to IE8 without jQuery
-      window.attachEvent('onload', function() {window.ReactRailsUJS.mountComponents()});
-    }
-  }
-
-  if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
-    handleTurbolinksEvents();
-  } else {
-    handleNativeEvents();
-  }
 })(document, window);

--- a/lib/assets/javascripts/react_ujs_native.js
+++ b/lib/assets/javascripts/react_ujs_native.js
@@ -1,0 +1,18 @@
+;(function(document, window) {
+  // jQuery is optional. Use it to support legacy browsers.
+  var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+
+  window.ReactRailsUJS.Native = {
+    // Attach handlers to browser events to mount & unmount components
+    setup: function() {
+      if ($) {
+        $(function() {window.ReactRailsUJS.mountComponents()});
+      } else if ('addEventListener' in window) {
+        document.addEventListener('DOMContentLoaded', function() {window.ReactRailsUJS.mountComponents()});
+      } else {
+        // add support to IE8 without jQuery
+        window.attachEvent('onload', function() {window.ReactRailsUJS.mountComponents()});
+      }
+    }
+  };
+})(document, window);

--- a/lib/assets/javascripts/react_ujs_turbolinks.js
+++ b/lib/assets/javascripts/react_ujs_turbolinks.js
@@ -1,0 +1,9 @@
+;(function(document, window) {
+  window.ReactRailsUJS.Turbolinks = {
+    // Turbolinks 5+ got rid of named events (?!)
+    setup: function() {
+      ReactRailsUJS.handleEvent('turbolinks:load', function() {window.ReactRailsUJS.mountComponents()});
+      ReactRailsUJS.handleEvent('turbolinks:before-cache', function() {window.ReactRailsUJS.unmountComponents()});
+    }
+  };
+})(document, window);

--- a/lib/assets/javascripts/react_ujs_turbolinks_classic.js
+++ b/lib/assets/javascripts/react_ujs_turbolinks_classic.js
@@ -1,25 +1,10 @@
 ;(function(document, window) {
-  // jQuery is optional. Use it to support legacy browsers.
-  var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
-
   window.ReactRailsUJS.TurbolinksClassic = {
     // Attach handlers to Turbolinks-Classic events
     // for mounting and unmounting components
     setup: function() {
-      var handleEvent;
-
-      if ($) {
-        handleEvent = function(eventName, callback) {
-          $(document).on(eventName, callback);
-        };
-      } else {
-        handleEvent = function(eventName, callback) {
-          document.addEventListener(eventName, callback);
-        };
-      }
-      // Turbolinks.EVENTS is in version 2.4.0+
-      handleEvent(Turbolinks.EVENTS.CHANGE, function() {window.ReactRailsUJS.mountComponents()});
-      handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, function() {window.ReactRailsUJS.unmountComponents()});
+      ReactRailsUJS.handleEvent(Turbolinks.EVENTS.CHANGE, function() {window.ReactRailsUJS.mountComponents()});
+      ReactRailsUJS.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, function() {window.ReactRailsUJS.unmountComponents()});
     }
   };
 })(document, window);

--- a/lib/assets/javascripts/react_ujs_turbolinks_classic.js
+++ b/lib/assets/javascripts/react_ujs_turbolinks_classic.js
@@ -1,0 +1,25 @@
+;(function(document, window) {
+  // jQuery is optional. Use it to support legacy browsers.
+  var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+
+  window.ReactRailsUJS.TurbolinksClassic = {
+    // Attach handlers to Turbolinks-Classic events
+    // for mounting and unmounting components
+    setup: function() {
+      var handleEvent;
+
+      if ($) {
+        handleEvent = function(eventName, callback) {
+          $(document).on(eventName, callback);
+        };
+      } else {
+        handleEvent = function(eventName, callback) {
+          document.addEventListener(eventName, callback);
+        };
+      }
+      // Turbolinks.EVENTS is in version 2.4.0+
+      handleEvent(Turbolinks.EVENTS.CHANGE, function() {window.ReactRailsUJS.mountComponents()});
+      handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, function() {window.ReactRailsUJS.unmountComponents()});
+    }
+  };
+})(document, window);

--- a/lib/assets/javascripts/react_ujs_turbolinks_classic_deprecated.js
+++ b/lib/assets/javascripts/react_ujs_turbolinks_classic_deprecated.js
@@ -1,0 +1,13 @@
+;(function(document, window) {
+  window.ReactRailsUJS.TurbolinksClassicDeprecated = {
+    // Before Turbolinks 2.4.0, Turbolinks didn't
+    // have named events and didn't have a before-unload event.
+    // Also, it didn't work with the Turbolinks cache, see
+    // https://github.com/reactjs/react-rails/issues/87
+    setup: function() {
+      Turbolinks.pagesCached(0)
+      ReactRailsUJS.handleEvent('page:change', function() {window.ReactRailsUJS.mountComponents()});
+      ReactRailsUJS.handleEvent('page:receive', function() {window.ReactRailsUJS.unmountComponents()});
+    }
+  };
+})(document, window);

--- a/test/react/rails/react_rails_ujs_test.rb
+++ b/test/react/rails/react_rails_ujs_test.rb
@@ -60,24 +60,26 @@ class ReactRailsUJSTest < ActionDispatch::IntegrationTest
 
     # Try clicking links.
     page.click_link('Alice')
+    wait_for_turbolinks_to_be_available
     assert page.has_content?('Hello Alice')
 
     page.click_link('Bob')
+    wait_for_turbolinks_to_be_available
     assert page.has_content?('Hello Bob')
 
     # Try going back.
     page.execute_script('history.back();')
+    wait_for_turbolinks_to_be_available
     assert page.has_content?('Hello Alice')
-
-    wait_for_turbolinks_to_be_available()
 
     # Try Turbolinks javascript API.
     page.execute_script('Turbolinks.visit("/pages/2");')
+    wait_for_turbolinks_to_be_available
     assert page.has_content?('Hello Alice')
 
-    wait_for_turbolinks_to_be_available()
 
     page.execute_script('Turbolinks.visit("/pages/1");')
+    wait_for_turbolinks_to_be_available
     assert page.has_content?('Hello Bob')
 
     # Component state is not persistent after clicking current page link.
@@ -85,6 +87,7 @@ class ReactRailsUJSTest < ActionDispatch::IntegrationTest
     assert page.has_content?('Goodbye Bob')
 
     page.click_link('Bob')
+    wait_for_turbolinks_to_be_available
     assert page.has_content?('Hello Bob')
   end
 

--- a/test/react/rails/react_rails_ujs_test.rb
+++ b/test/react/rails/react_rails_ujs_test.rb
@@ -56,6 +56,7 @@ class ReactRailsUJSTest < ActionDispatch::IntegrationTest
   test 'react_ujs works with Turbolinks' do
     visit '/pages/1'
     assert page.has_content?('Hello Bob')
+    assert page.evaluate_script("Turbolinks.supported")
 
     # Try clicking links.
     page.click_link('Alice')

--- a/test/react/server_rendering/manifest_container_test.rb
+++ b/test/react/server_rendering/manifest_container_test.rb
@@ -5,7 +5,9 @@ require "test_helper"
 if Rails::VERSION::MAJOR > 3
   class ManifestContainerTest < ActiveSupport::TestCase
     def setup
-      precompile_assets
+      capture_io do
+        precompile_assets
+      end
 
       # Make a new manifest since assets weren't compiled before
       config = Rails.application.config

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,8 @@ def precompile_assets
 end
 
 def clear_precompiled_assets
-  FileUtils.rm_r(File.expand_path("../dummy/public/assets", __FILE__))
+  assets_directory = File.expand_path("../dummy/public/assets", __FILE__)
+  FileUtils.rm_r(assets_directory)
   ENV.delete('RAILS_GROUPS')
 end
 


### PR DESCRIPTION
Turbolinks 5 might have some different APIs to support. We want to support all of them!

I think this a good chance to split the UJS into different files. I hope it will make it easier for new people to find the code they want to change & work on it. Also, you could "mix & match" the UJS if you didn't want certain parts of it. 

- [x] Refactor UJS into responsibility-specific files 
- [x] Support Turbolinks 2.4.0+ only (a smaller version will throw an error, you could work around it by assigning `Turbolinks.EVENTS` yourself)
- [x] Add gemfiles specifying Turbolinks 5 / Turbolinks Classic
- [x] Detect & support Turbolinks 5
- [x] Install a recent version of PhantomJS so that the tests _actually_ test Turbolinks!
- [x] Force specific turbolinks versions