### PR TITLE
Fixing install generator to have inserted content properly on the new Line

### DIFF
--- a/lib/generators/react/install_generator.rb
+++ b/lib/generators/react/install_generator.rb
@@ -22,7 +22,7 @@ module React
         if manifest.exist?
           manifest_contents = File.read(manifest)
 
-          if match = manifest_contents.match(/\/\/=\s+require\s+turbolinks/)
+          if match = manifest_contents.match(/\/\/=\s+require\s+turbolinks\s+\n/)
             inject_into_file manifest, require_react, { after: match[0] }
           elsif match = manifest_contents.match(/\/\/=\s+require_tree[^\n]*/)
             inject_into_file manifest, require_react, { before: match[0] }

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -30,15 +30,14 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     File.delete destination_root + '/app/assets/javascripts/application.js'
 
     run_generator
-
-    assert_application_file_modified
+    assert_application_file_created
   end
 
   test "modifies `application.js` if it's empty" do
     init_application_js ''
 
     run_generator
-    assert_application_file_modified
+    assert_application_file_created
   end
 
   test "updates `application.js` if require_tree is commented" do
@@ -68,9 +67,14 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     File.write destination_root + '/app/assets/javascripts/application.js', content
   end
 
+  def assert_application_file_created
+    assert_file 'app/assets/javascripts/application.js',
+                %r{//= require react\n//= require react_ujs\n//= require components\n}
+  end
+
   def assert_application_file_modified
-    assert_file 'app/assets/javascripts/application.js', %r{//= require react}
-    assert_file 'app/assets/javascripts/application.js', %r{//= require react_ujs}
-    assert_file 'app/assets/javascripts/application.js', %r{//= require components}
+    assert_file 'app/assets/javascripts/application.js', %r{\n//= require react\n}
+    assert_file 'app/assets/javascripts/application.js', %r{\n//= require react_ujs\n}
+    assert_file 'app/assets/javascripts/application.js', %r{\n//= require components\n}
   end
 end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -16,7 +16,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "adds requires to `application.js`" do
     run_generator
 
-    assert_application_file_modified
+    assert_application_file_created
   end
 
   test "it modifes an existing 'application.js'" do


### PR DESCRIPTION
When used `rails g react:install`, it generated modified `application.js` as given below.

```diff
//
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
+//= require turbolinks//= require react
+//= require react_ujs
+//= require components
+
```
Made changes to have inserted content on the new line.