### PR TITLE
Use Manifest#dir for sprockets 3 compatibility

### DIFF
--- a/lib/react/server_rendering/manifest_container.rb
+++ b/lib/react/server_rendering/manifest_container.rb
@@ -11,7 +11,7 @@ module React
 
       def find_asset(logical_path)
         asset_path = @manifest.assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
-        asset_full_path = ::Rails.root.join("public", @manifest.directory, asset_path)
+        asset_full_path = ::Rails.root.join("public", @manifest.dir, asset_path)
         File.read(asset_full_path)
       end
     end


### PR DESCRIPTION
This changed in sprockets a while ago https://github.com/rails/sprockets/commit/3255c8ce8623d54dcf1d7676c45963da492237cd
But it's nice to support those using the ancient 3.X version.