### PR TITLE
Add support for nested arrays in camelize_props

### DIFF
--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -49,7 +49,15 @@ module React
       def camelize_props_key(props)
         return props unless props.is_a?(Hash)
         props.inject({}) do |h, (k,v)|
-          h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v; h
+          h[k.to_s.camelize(:lower)] = case v
+          when Hash
+            camelize_props_key(v)
+          when Array
+            v.map {|i| camelize_props_key(i) }
+          else
+            v
+          end
+          h
         end
       end
     end

--- a/test/react/rails/component_mount_test.rb
+++ b/test/react/rails/component_mount_test.rb
@@ -13,11 +13,21 @@ class ComponentMountTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test '#react_component accepts React props with camelize_props ' do
+  test '#react_component accepts React props with camelize_props' do
     React::Rails::ComponentMount.camelize_props_switch = true
     helper = React::Rails::ComponentMount.new
     html = helper.react_component('Foo', {foo_bar: 'value'})
     expected_props = %w(data-react-class="Foo" data-react-props="{&quot;fooBar&quot;:&quot;value&quot;}")
+    expected_props.each do |segment|
+      assert html.include?(segment)
+    end
+  end
+
+  test '#react_component accepts React props with camelize_props containing nested arrays' do
+    React::Rails::ComponentMount.camelize_props_switch = true
+    helper = React::Rails::ComponentMount.new
+    html = helper.react_component('Foo', {foo_bar: [{user_name: 'Ryan'}, {user_name: 'Matt'}], bar_foo: 1})
+    expected_props = %w(data-react-class="Foo" data-react-props="{&quot;fooBar&quot;:[{&quot;userName&quot;:&quot;Ryan&quot;},{&quot;userName&quot;:&quot;Matt&quot;}],&quot;barFoo&quot;:1}")
     expected_props.each do |segment|
       assert html.include?(segment)
     end


### PR DESCRIPTION
In it's current implementation `camelize_props` only supports nested hashes.

    {foo_bar: {user: {id: 1, user_name: 'ryan'}}}

converts to 

    {fooBar: {user: {id: 1, userName: 'ryan'}}

However nested arrays that contain hashes are left unchanged.

    {foo_bar: [{id: 1, user_name: 'ryan'}, {id: 2, user_name: 'Matt'}]}

converts to

    {fooBar: [{id: 1, user_name: 'ryan'}, {id: 2, user_name: 'Matt'}]}

This PR adds support for nested arrays that contain hashes. After this commit it converts to:

    {fooBar: [{id: 1, userName: 'ryan'}, {id: 2, userName: 'Matt'}]}
