### PR TITLE
Add YamlManifestContainer for Rails 3.2 server rendering support

### DIFF
--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -1,5 +1,7 @@
 require "react/server_rendering/environment_container"
 require "react/server_rendering/manifest_container"
+require "react/server_rendering/yaml_manifest_container"
+
 module React
   module ServerRendering
     # Extends ExecJSRenderer for the Rails environment
@@ -62,7 +64,11 @@ module React
         elsif ::Rails.application.config.assets.compile
           EnvironmentContainer.new
         else
-          ManifestContainer.new
+          if Rails::VERSION::MAJOR == 3
+            YamlManifestContainer.new
+          else
+            ManifestContainer.new
+          end
         end
       end
     end

--- a/lib/react/server_rendering/yaml_manifest_container.rb
+++ b/lib/react/server_rendering/yaml_manifest_container.rb
@@ -1,0 +1,19 @@
+module React
+  module ServerRendering
+    # Get asset content by reading the compiled file from disk using the generated maniftest.yml file
+    #
+    # This is good for Rails production when assets are compiled to public/assets
+    # but sometimes, they're compiled to other directories (or other servers)
+    class YamlManifestContainer
+      def initialize
+        @assets = YAML.load_file(::Rails.root.join("public/assets/manifest.yml"))
+      end
+
+      def find_asset(logical_path)
+        asset_path = @assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
+        asset_full_path = ::Rails.root.join("public", "assets", asset_path)
+        File.read(asset_full_path)
+      end
+    end
+  end
+end

--- a/test/react/server_rendering/yaml_manifest_container_test.rb
+++ b/test/react/server_rendering/yaml_manifest_container_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+if Rails::VERSION::MAJOR == 3
+  class YamlManifestContainerTest < ActiveSupport::TestCase
+    def setup
+      precompile_assets
+
+      @manifest_container = React::ServerRendering::YamlManifestContainer.new
+    end
+
+    def teardown
+      clear_precompiled_assets
+    end
+
+    def test_find_asset_gets_asset_contents
+      application_js_content = @manifest_container.find_asset("application.js")
+      assert(application_js_content.length > 50000, "It's the compiled file")
+    end
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,7 +48,7 @@ end
 
 def clear_precompiled_assets
   assets_directory = File.expand_path("../dummy/public/assets", __FILE__)
-  FileUtils.rm_r(assets_directory)
+  FileUtils.rm_rf(assets_directory)
   ENV.delete('RAILS_GROUPS')
 end
 


### PR DESCRIPTION
Based on discussions with @rmosolgo this PR restores full support for Rails 3.2, specifically server rendering with precompiled assets.

Closes #483 and Closes #484 

Added tests pass but `react_test/precompiling assets works` throws an error when trying to call `clear_precompiled_assets`