### PR TITLE
Fix Rails reference in SprocketsRenderer

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,6 @@
 appraise "rails-3.2" do
   gem 'rails', '~> 3.2.21'
+  gem 'rack-cache', '~> 1.6.1'
 end
 
 appraise "rails-4.0" do

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -3,5 +3,6 @@
 source "http://rubygems.org"
 
 gem "rails", "~> 3.2.21"
+gem "rack-cache", "~> 1.6.1"
 
 gemspec :path => "../"

--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -64,7 +64,7 @@ module React
         elsif ::Rails.application.config.assets.compile
           EnvironmentContainer.new
         else
-          if Rails::VERSION::MAJOR == 3
+          if ::Rails::VERSION::MAJOR == 3
             YamlManifestContainer.new
           else
             ManifestContainer.new

--- a/test/react/server_rendering/manifest_container_test.rb
+++ b/test/react/server_rendering/manifest_container_test.rb
@@ -5,15 +5,7 @@ require "test_helper"
 if Rails::VERSION::MAJOR > 3
   class ManifestContainerTest < ActiveSupport::TestCase
     def setup
-      capture_io do
-        precompile_assets
-      end
-
-      # Make a new manifest since assets weren't compiled before
-      config = Rails.application.config
-      path = File.join(config.paths['public'].first, config.assets.prefix)
-      new_manifest = Sprockets::Manifest.new(Rails.application.assets, path)
-      Rails.application.assets_manifest = new_manifest
+      precompile_assets
 
       @manifest_container = React::ServerRendering::ManifestContainer.new
     end

--- a/test/react/server_rendering/sprockets_renderer_test.rb
+++ b/test/react/server_rendering/sprockets_renderer_test.rb
@@ -57,6 +57,9 @@ class SprocketsRendererTest < ActiveSupport::TestCase
 
   test '#render returns html when config.assets.compile is false' do
     begin
+      Rails.application.config.assets.precompile += [
+        "react-server.js", "components.js"]
+
       precompile_assets
 
       Rails.application.config.assets.compile = false

--- a/test/react/server_rendering/sprockets_renderer_test.rb
+++ b/test/react/server_rendering/sprockets_renderer_test.rb
@@ -54,4 +54,22 @@ class SprocketsRendererTest < ActiveSupport::TestCase
     end
     assert_match(/ReferenceError/, err.to_s, "it doesnt load other files")
   end
+
+  test '#render returns html when config.assets.compile is false' do
+    begin
+      precompile_assets
+
+      Rails.application.config.assets.compile = false
+
+      @renderer = React::ServerRendering::SprocketsRenderer.new({})
+
+      result = @renderer.render("Todo", {todo: "write tests"}, nil)
+      assert_match(/<li.*write tests<\/li>/, result)
+      assert_match(/data-react-checksum/, result)
+    ensure
+      Rails.application.config.assets.compile = true
+
+      clear_precompiled_assets
+    end
+  end
 end


### PR DESCRIPTION
Hi @rmosolgo!

Unfortunately I found an issue with [the code we just merged](https://github.com/reactjs/react-rails/blob/master/lib/react/server_rendering/sprockets_renderer.rb#L67) that checks the Rails version in `SprocketsRenderer`. Rather than reference the top level `Rails` class using `::Rails` I mistakenly referenced plain old `Rails` which in this context is `React::Rails`. I expected that to be tested but on second glance saw it was not. This PR fixes that reference plus adds test coverage for `SprocketsRenderer` when `Rails.application.config.assets.compile == false`.

I've also fixed a few issues I found with the test helper's `precompile_assets` method. Let me know what you think. :dog: 