### PR TITLE
Fix bug with console replay and carriage returns

### DIFF
--- a/lib/react/server_rendering/sprockets_renderer/console_replay.js
+++ b/lib/react/server_rendering/sprockets_renderer/console_replay.js
@@ -1,9 +1,9 @@
 (function (history) {
   if (history && history.length > 0) {
-    result += '\\n<scr'+'ipt>';
+    result += '\n<scr'+'ipt>';
     history.forEach(function (msg) {
-      result += '\\nconsole.' + msg.level + '.apply(console, ' + JSON.stringify(msg.arguments) + ');';
+      result += '\nconsole.' + msg.level + '.apply(console, ' + JSON.stringify(msg.arguments) + ');';
     });
-    result += '\\n</scr'+'ipt>';
+    result += '\n</scr'+'ipt>';
   }
 })(console.history);

--- a/test/react/server_rendering/sprockets_renderer_test.rb
+++ b/test/react/server_rendering/sprockets_renderer_test.rb
@@ -24,9 +24,10 @@ class SprocketsRendererTest < ActiveSupport::TestCase
 
   test '#render replays console messages' do
     result = @renderer.render("TodoListWithConsoleLog", {todos: ["log some messages"]}, nil)
-    assert_match(/console.log.apply\(console, \["got initial state"\]\)/, result)
-    assert_match(/console.warn.apply\(console, \["mounted component"\]\)/, result)
-    assert_match(/console.error.apply\(console, \["rendered!","foo"\]\)/, result)
+    assert_match(/<script>$/, result)
+    assert_match(/console.log.apply\(console, \["got initial state"\]\);$/, result)
+    assert_match(/console.warn.apply\(console, \["mounted component"\]\);$/, result)
+    assert_match(/console.error.apply\(console, \["rendered!","foo"\]\);$/, result)
   end
 
   test '#render console messages can be disabled' do


### PR DESCRIPTION
Code from Ruby string days was still in the standalone JS file and it caused browsers to complain. Tightened up the regex to catch this in tests.

Fixes https://github.com/reactjs/react-rails/issues/494