### PR TITLE
When a static render is done, don't include react class/props

### DIFF
--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -32,9 +32,11 @@ module React
         end
 
         html_options = options.reverse_merge(:data => {})
-        html_options[:data].tap do |data|
-          data[:react_class] = name
-          data[:react_props] = (props.is_a?(String) ? props : props.to_json)
+        unless prerender_options == :static
+          html_options[:data].tap do |data|
+            data[:react_class] = name
+            data[:react_props] = (props.is_a?(String) ? props : props.to_json)
+          end
         end
         html_tag = html_options[:tag] || :div
 

--- a/test/react/rails/component_mount_test.rb
+++ b/test/react/rails/component_mount_test.rb
@@ -58,6 +58,11 @@ class ComponentMountTest < ActionDispatch::IntegrationTest
     assert(!html.include?('data-reactid'), "it DOESNT INCLUDE React properties")
   end
 
+  test '#react_component does not include HTML properties with a static render' do
+    html = @helper.react_component('Todo', {todo: 'render on the server'}.to_json, prerender: :static)
+    assert_equal('<div><li>render on the server</li></div>', html)
+  end
+
   test '#react_component accepts HTML options and HTML tag' do
     assert @helper.react_component('Foo', {}, :span).match(/<span\s.*><\/span>/)
 


### PR DESCRIPTION
Should result in cleaner markup in cases where the client side React won't be rendered anyways.

Alternatively, this could be an option but it seems like a sensible default to me.