### PR TITLE
Update to accept new babel 6 module exports

### DIFF
--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -16,7 +16,7 @@
 
     // If that didn't work, try eval
     if (!constructor) {
-      constructor = eval.call(window, className)'
+      constructor = eval.call(window, className);
     }
 
     // Lastly, if there is a default attribute try that

--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -2,6 +2,31 @@
   // jQuery is optional. Use it to support legacy browsers.
   var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
 
+  // Get the constructor for a className
+  // Not a part of the public API
+  function getConstructor(className) {
+    // Assume className is simple and can be found at top-level (window).
+    // Fallback to eval to handle cases like 'My.React.ComponentName'.
+    // Also, try to gracefully import Babel 6 style default exports
+    //
+    var constructor;
+
+    // Try to access the class globally first
+    constructor = window[className];
+
+    // If that didn't work, try eval
+    if (!constructor) {
+      constructor = eval.call(window, className)'
+    }
+
+    // Lastly, if there is a default attribute try that
+    if (constructor && constructor.default) {
+      constructor = constructor.default;
+    }
+
+    return constructor;
+  }
+
   window.ReactRailsUJS = {
     // This attribute holds the name of component which should be mounted
     // example: `data-react-class="MyApp.Items.EditForm"`
@@ -50,10 +75,7 @@
       for (var i = 0; i < nodes.length; ++i) {
         var node = nodes[i];
         var className = node.getAttribute(window.ReactRailsUJS.CLASS_NAME_ATTR);
-
-        // Assume className is simple and can be found at top-level (window).
-        // Fallback to eval to handle cases like 'My.React.ComponentName'.
-        var constructor = window[className].default || window[className] || eval.call(window, className);
+        var constructor = getConstructor(className);
         var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
         var props = propsJson && JSON.parse(propsJson);
 

--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -67,6 +67,30 @@
       }
     },
 
+    // Get the constructor for a className
+    getConstructor: function(className) {
+      // Assume className is simple and can be found at top-level (window).
+      // Fallback to eval to handle cases like 'My.React.ComponentName'.
+      // Also, try to gracefully import Babel 6 style default exports
+      //
+      var constructor;
+
+      // Try to access the class globally first
+      constructor = window[className];
+
+      // If that didn't work, try eval
+      if (!constructor) {
+        constructor = eval.call(window, className);
+      }
+
+      // Lastly, if there is a default attribute try that
+      if (constructor && constructor.default) {
+        constructor = constructor.default;
+      }
+
+      return constructor;
+    },
+
     // Within `searchSelector`, find nodes which should have React components
     // inside them, and mount them with their props.
     mountComponents: function(searchSelector) {
@@ -75,7 +99,7 @@
       for (var i = 0; i < nodes.length; ++i) {
         var node = nodes[i];
         var className = node.getAttribute(window.ReactRailsUJS.CLASS_NAME_ATTR);
-        var constructor = getConstructor(className);
+        var constructor = this.getConstructor(className);
         var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
         var props = propsJson && JSON.parse(propsJson);
 

--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -2,31 +2,6 @@
   // jQuery is optional. Use it to support legacy browsers.
   var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
 
-  // Get the constructor for a className
-  // Not a part of the public API
-  function getConstructor(className) {
-    // Assume className is simple and can be found at top-level (window).
-    // Fallback to eval to handle cases like 'My.React.ComponentName'.
-    // Also, try to gracefully import Babel 6 style default exports
-    //
-    var constructor;
-
-    // Try to access the class globally first
-    constructor = window[className];
-
-    // If that didn't work, try eval
-    if (!constructor) {
-      constructor = eval.call(window, className);
-    }
-
-    // Lastly, if there is a default attribute try that
-    if (constructor && constructor.default) {
-      constructor = constructor.default;
-    }
-
-    return constructor;
-  }
-
   window.ReactRailsUJS = {
     // This attribute holds the name of component which should be mounted
     // example: `data-react-class="MyApp.Items.EditForm"`

--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -53,7 +53,7 @@
 
         // Assume className is simple and can be found at top-level (window).
         // Fallback to eval to handle cases like 'My.React.ComponentName'.
-        var constructor = window[className] || eval.call(window, className);
+        var constructor = window[className].default || window[className] || eval.call(window, className);
         var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
         var props = propsJson && JSON.parse(propsJson);
 


### PR DESCRIPTION
With the update to Babel 6, modules are being exported differently. For
instance, the default module is now under a default key. This is
breaking things when using an expose loader with webpack. This adds a
check for that before trying to import the module.