### PR TITLE
fix(build): use alternate url for phantomjs to avoid 403 throttling errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 before_install:
   - mkdir travis-phantomjs
-  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - wget https://cnpmjs.org/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - phantomjs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
 
 before_install:
   - mkdir travis-phantomjs
-  - wget https://cnpmjs.org/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - wget https://rmosolgo.github.io/assets/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - phantomjs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 cache: bundler
 rvm:
   - 2.3.0
-  - 2.2.4
   - 2.1
   - jruby-9.0.1.0
 
@@ -19,8 +18,25 @@ gemfile:
 matrix:
   fast_finish: true
   exclude:
-    - gemfile: gemfiles/rails_5.gemfile
-      rvm: 2.1
+    - rvm: 2.1
+      gemfile: gemfiles/rails_4.0.gemfile
+    - rvm: 2.1
+      gemfile: rails_4.0_with_therubyracer.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/rails_4.2_sprockets_2.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/rails_5.gemfile
+    - rvm: jruby-9.0.1.0
+      gemfile: gemfiles/rails_4.0.gemfile
+    - rvm: jruby-9.0.1.0
+      gemfile: rails_4.0_with_therubyracer.gemfile
+    - rvm: jruby-9.0.1.0
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: jruby-9.0.1.0
+      gemfile: gemfiles/rails_4.2_sprockets_2.gemfile
+
   allow_failures:
     - rvm: jruby-9.0.1.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.pattern = ENV['TEST_PATTERN'] || 'test/**/*_test.rb'
   t.verbose = ENV['TEST_VERBOSE'] == '1'
+  t.warning = false
 end
 
 task default: :test

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-minitest'
   s.add_development_dependency 'jbuilder'
+  s.add_development_dependency 'listen', '~> 3.0.0' # support Ruby 2.1
   s.add_development_dependency 'poltergeist', '>= 0.3.3'
   s.add_development_dependency 'test-unit', '~> 2.5'
   s.add_development_dependency 'turbolinks', '>= 2.0.0'


### PR DESCRIPTION
The old endpoint is throttled