### PR TITLE
fix(JS): unmount components during 'turbolinks:before-render' for Turbolinks 5

### DIFF
--- a/lib/assets/javascripts/react_ujs_turbolinks.js
+++ b/lib/assets/javascripts/react_ujs_turbolinks.js
@@ -3,7 +3,7 @@
     // Turbolinks 5+ got rid of named events (?!)
     setup: function() {
       ReactRailsUJS.handleEvent('turbolinks:load', function() {window.ReactRailsUJS.mountComponents()});
-      ReactRailsUJS.handleEvent('turbolinks:before-cache', function() {window.ReactRailsUJS.unmountComponents()});
+      ReactRailsUJS.handleEvent('turbolinks:before-render', function() {window.ReactRailsUJS.unmountComponents()});
     }
   };
 })(document, window);


### PR DESCRIPTION
This event is a bit later, it looks better to do it this way