### PR TITLE
Fix Rails 5 .to_prepare deprecation warning

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -85,7 +85,11 @@ module React
 
         React::ServerRendering.reset_pool
         # Reload renderers in dev when files change
-        ActionDispatch::Reloader.to_prepare { React::ServerRendering.reset_pool }
+        if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new("5.x")
+          ActiveSupport::Reloader.to_prepare { React::ServerRendering.reset_pool }
+        else
+          ActionDispatch::Reloader.to_prepare { React::ServerRendering.reset_pool }
+        end
       end
 
       initializer "react_rails.setup_engine", :group => :all do |app|


### PR DESCRIPTION
### Changes

In rails/rails@d3c9d808e3e242155a44fd2a89ef272cfade8fe8, `ActionDispatch::Reloader.to_prepare` (and friends) were moved to `ActiveSupport`.

For now, they're only issuing a deprecation warning, but they're planning on dropping support in Rails 5.1.

> `DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1 (use ActiveSupport::Reloader.to_prepare instead)`

### Testing

I didn't have a great way to add a test for this, but the implementation seems pretty straightforward.  I've tested that the gem works with an app in development.  The app doesn't actually use server rendering, but it does boot and otherwise work great.