### PR TITLE
feat(UJS) show helpful error messages for missing components

### DIFF
--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -57,7 +57,14 @@
         var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
         var props = propsJson && JSON.parse(propsJson);
 
-        ReactDOM.render(React.createElement(constructor, props), node);
+        if (typeof(constructor) === "undefined") {
+          var message = "Cannot find component: '" + className + "'"
+          if (console && console.log) { console.log("%c[react-rails] %c" + message + " for element", "font-weight: bold", "", node) }
+          var error = new Error(message + ". Make sure your component is globally available to render.")
+          throw error
+        } else {
+          ReactDOM.render(React.createElement(constructor, props), node);
+        }
       }
     },
 


### PR DESCRIPTION
The Problem
-----------

Currently, if you use an invalid component name in `data-react-class`,
you get a React invariant error that only tells you that the component
class was undefined, but it doesn't actually help you fix the error. I
end up needing to scroll backwards in the stack trace until I find this
part of the `react_ujs_mount.js` code and inspect the value of
`className`

![screen shot 2016-05-25 at 11 36 04 am](https://cloud.githubusercontent.com/assets/993340/15551939/1c3517b6-226d-11e6-9535-36d040ee52d6.png)

The Solution
------------

Throw a helpful error (and nice console log message) about an invalid
className at the moment we try to mount the component. You can even right-click
and `Reveal in Elements Panel` to see exactly where the element is in the DOM!

![screen shot 2016-05-25 at 11 37 23 am](https://cloud.githubusercontent.com/assets/993340/15551944/21284e96-226d-11e6-90d1-5bd459e6b6fd.png)
