### PR TITLE
feat(ujs) add react:ujs generator for customizing UJS

### DIFF
--- a/lib/generators/react/ujs_generator.rb
+++ b/lib/generators/react/ujs_generator.rb
@@ -1,0 +1,44 @@
+module React
+  module Generators
+    class UjsGenerator < ::Rails::Generators::Base
+      desc "Create a custom copy of react_ujs for your application"
+
+      class_option :output, required: true, desc: "File path for new react_ujs.js"
+
+      class_option :turbolinks, type: :boolean, default: true, desc: "Include Turbolinks 5 support?"
+      class_option :turbolinks_classic, type: :boolean, default: true, desc: "Include Turbolinks 2.4 / 3 support?"
+      class_option :turbolinks_classic_deprecated, type: :boolean, default: true, desc: "Include Turbolinks < 2.4 support?"
+      class_option :pjax, type: :boolean, default: true, desc: "Include PJAX support?"
+      class_option :native, type: :boolean, default: true, desc: "Include native events support?"
+
+      EVENT_SUPPORT_OPTIONS = [
+        :turbolinks,
+        :turbolinks_classic,
+        :turbolinks_classic_deprecated,
+        :pjax,
+        :native,
+      ]
+
+      def create_ujs_file
+        files_to_merge = ["react_ujs_mount.js"]
+
+        EVENT_SUPPORT_OPTIONS.each do |event_support_option|
+          if options[event_support_option]
+            files_to_merge << "react_ujs_#{event_support_option}.js"
+          end
+        end
+
+        files_to_merge << "react_ujs_event_setup.js"
+
+        asset_dir = File.expand_path("../../../assets/javascripts", __FILE__)
+
+        custom_ujs_content = files_to_merge
+          .map { |filename| File.read(File.join(asset_dir, filename)) }
+          .join("\n")
+
+        new_ujs_path = options[:output]
+        create_file(new_ujs_path, custom_ujs_content)
+      end
+    end
+  end
+end

--- a/test/generators/ujs_generator_test.rb
+++ b/test/generators/ujs_generator_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'generators/react/ujs_generator'
+
+class UjsGeneratorTest < Rails::Generators::TestCase
+  destination File.join(Rails.root, 'tmp', 'ujs_generator')
+  tests React::Generators::UjsGenerator
+  setup :prepare_destination
+
+  test "it includes all event support by default" do
+    run_generator %w(--output=custom/react_ujs.js)
+
+    assert_file "custom/react_ujs.js" do |generated_js|
+      assert_match /ReactRailsUJS\.Turbolinks =/, generated_js
+      assert_match /ReactRailsUJS\.TurbolinksClassic =/, generated_js
+      assert_match /ReactRailsUJS\.TurbolinksClassicDeprecated =/, generated_js
+      assert_match /ReactRailsUJS\.pjax =/, generated_js
+      assert_match /ReactRailsUJS\.Native =/, generated_js
+    end
+  end
+
+  test "it can skip some event support" do
+    run_generator %w(--output=custom/react_ujs_2.js --pjax=false --native=false --turbolinks_classic_deprecated=false)
+
+    assert_file "custom/react_ujs_2.js" do |generated_js|
+      assert_match /ReactRailsUJS\.Turbolinks =/, generated_js
+      assert_match /ReactRailsUJS\.TurbolinksClassic =/, generated_js
+      assert_no_match /ReactRailsUJS\.TurbolinksClassicDeprecated =/, generated_js
+      assert_no_match /ReactRailsUJS\.pjax =/, generated_js
+      assert_no_match /ReactRailsUJS\.Native =/, generated_js
+    end
+  end
+end


### PR DESCRIPTION
In a recent version, I split the UJS into many files, then `//= require` them together with Sprockets. This is great for code generation but bad for someone who wants to use the code in a non-Sprockets setup. 

Add `rails generate react:ujs --output=my/custom/react_ujs.js --turbolinks_classic_deprecated=false --pjax=false --native=false" for people who want to copy the UJS into their own setups.

