### PR TITLE
Silence sprockets 3.7.0 deprecation warnings

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -107,7 +107,7 @@ module React
             sprockets_env.register_mime_type("application/jsx+coffee", extensions: [".jsx.coffee", ".js.jsx.coffee"])
             sprockets_env.register_transformer("application/jsx+coffee", "application/jsx", Sprockets::CoffeeScriptProcessor)
           elsif Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new("3.0.0")
-            sprockets_env.register_engine(".jsx", React::JSX::Processor, mime_type: "application/javascript")
+            sprockets_env.register_engine(".jsx", React::JSX::Processor, mime_type: "application/javascript", silence_deprecation: true)
           else
             sprockets_env.register_engine(".jsx", React::JSX::Template)
           end


### PR DESCRIPTION
react-rails 1.8.0 throws deprecation warnings when using sprockets 3.7.0.

```
% bin/rails c
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then use `register_compressor` or `register_transformer`.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from block in <class:Railtie> at /path/to/react-rails-1.8.0/lib/react/rails/railtie.rb:110)
Loading development environment (Rails 4.2.7)
[1] pry(main)>
```

Same problem has been fixed in rails/sass-rails#381