### PR TITLE
Allow configurability of React/ReactDOM instance per component

### DIFF
--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -11,6 +11,9 @@
     // example: `data-react-props="{\"item\": { \"id\": 1, \"name\": \"My Item\"} }"`
     PROPS_ATTR: 'data-react-props',
 
+    REACT_ATTR: 'data-react-name',
+    REACT_DOM_ATTR: 'data-react-dom-name',
+
     // helper method for the mount and unmount methods to find the
     // `data-react-class` DOM elements
     findDOMNodes: function(searchSelector) {
@@ -77,6 +80,8 @@
         var constructor = this.getConstructor(className);
         var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
         var props = propsJson && JSON.parse(propsJson);
+        var reactDomInstance = getReactDomInstanceAtNode(node);
+        var reactInstance = getReactInstanceAtNode(node);
 
         if (typeof(constructor) === "undefined") {
           var message = "Cannot find component: '" + className + "'"
@@ -84,7 +89,7 @@
           var error = new Error(message + ". Make sure your component is globally available to render.")
           throw error
         } else {
-          ReactDOM.render(React.createElement(constructor, props), node);
+          reactDomInstance.render(reactInstance.createElement(constructor, props), node);
         }
       }
     },
@@ -96,9 +101,30 @@
 
       for (var i = 0; i < nodes.length; ++i) {
         var node = nodes[i];
+        var reactDomInstance = getReactDomInstanceAtNode(node);
 
-        ReactDOM.unmountComponentAtNode(node);
+        reactDomInstance.unmountComponentAtNode(node);
       }
     }
   };
+
+  function getReactDomInstanceAtNode(node) {
+    var reactDomProp = node.getAttribute(window.ReactRailsUJS.REACT_DOM_ATTR);
+
+    try {
+      return window[reactDomProp] || eval.call(window, reactDomProp);
+    } catch {
+      return ReactDOM;
+    }
+  }
+
+  function getReactInstanceAtNode(node) {
+    var reactProp = node.getAttribute(window.ReactRailsUJS.REACT_ATTR);
+
+    try {
+      return window[reactProp] || eval.call(window, reactProp);
+    } catch {
+      return React;
+    }
+  }
 })(document, window);

--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -38,6 +38,9 @@ module React
           html_options[:data].tap do |data|
             data[:react_class] = name
             data[:react_props] = (props.is_a?(String) ? props : props.to_json)
+
+            data[:react_name] = options[:react_name]
+            data[:react_dom_name] = options[:react_dom_name]
           end
         end
         html_tag = html_options[:tag] || :div


### PR DESCRIPTION
Hi there,

This isn't a complete working/tested implementation. I'm just testing the waters to see if you guys would be amenable to a PR looking something like this.

**An example problem**

Imagine I've got 2 different widgets libraries being managed by 2 different teams. `widgets-core` is managed by 1 team, and is full of tried and true widgets built with React. `widgets-experimental` is full of the latest widgets being developed by a different team, also with React. Both teams deliver a .js file globally exposing their widgets and are separate from the Rails team.

I'm on the Rails team and everything is going great in my Rails app using `react-rails` until I start to use widgets form both `widgets-core` and `widgets-experimental` on the same page. They use different versions of React. The components are already unhappy with being rendered by a different version of React than they were defined with, but to make it worse, `widgets-core` is still pre-0.14 and `widgets-experimental` is using React 15.x, meaning that these versions of React have different rendering interfaces! I'm stuck!
## 

Hopefully that example wasn't too contrived. It's very similar to a problem that I'm experiencing. This PR represents a potential way to solve the problem. Imagine a Rails partial that looks like this

``` slim
= react_component('Widgets.Core.PrimaryWidget', 
  props, 
  { react_name: 'Widgets.Core.React',
    react_dom_name: 'Widgets.Core.React' })

= react_component('Widgets.Experimental.WizzBang', 
  props, 
  { react_name: 'Widgets.Experimental.React',
    react_dom_name: 'Widgets.Experimental.ReactDOM' })
```

This allows us our React components to be developed independently from the Rails app and to package up the React versions they need in order to render correctly.

Thoughts?

Totally open to suggestions and, of course, to renaming / shifting code around / whatever to conform to codebase style guides.
