### PR TITLE
Fix alt asset path

### DIFF
--- a/lib/react/server_rendering/yaml_manifest_container.rb
+++ b/lib/react/server_rendering/yaml_manifest_container.rb
@@ -6,12 +6,12 @@ module React
     # but sometimes, they're compiled to other directories (or other servers)
     class YamlManifestContainer
       def initialize
-        @assets = YAML.load_file(::Rails.root.join("public/assets/manifest.yml"))
+        @assets = YAML.load_file(::Rails.root.join("public", ::Rails.application.config.assets.prefix, "manifest.yml"))
       end
 
       def find_asset(logical_path)
         asset_path = @assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
-        asset_full_path = ::Rails.root.join("public", "assets", asset_path)
+        asset_full_path = ::Rails.root.join("public", ::Rails.application.config.assets.prefix, asset_path)
         File.read(asset_full_path)
       end
 

--- a/lib/react/server_rendering/yaml_manifest_container.rb
+++ b/lib/react/server_rendering/yaml_manifest_container.rb
@@ -10,7 +10,8 @@ module React
       end
 
       def find_asset(logical_path)
-        asset_path = @assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
+        asset_path = @assets[logical_path]
+        return "" unless asset_path
         asset_full_path = ::Rails.root.join("public", ::Rails.application.config.assets.prefix, asset_path)
         File.read(asset_full_path)
       end


### PR DESCRIPTION
Allow for a non-default asset path for compiled assets.

On initial deployments to new servers, skip files we haven't had the opportunity to compile yet.