### PR TITLE
Use assets prefix in yaml manifest path

### DIFF
--- a/lib/react/server_rendering/yaml_manifest_container.rb
+++ b/lib/react/server_rendering/yaml_manifest_container.rb
@@ -6,12 +6,12 @@ module React
     # but sometimes, they're compiled to other directories (or other servers)
     class YamlManifestContainer
       def initialize
-        @assets = YAML.load_file(::Rails.root.join("public/assets/manifest.yml"))
+        @assets = YAML.load_file(::Rails.root.join("public", ::Rails.application.config.assets.prefix, "manifest.yml"))
       end
 
       def find_asset(logical_path)
         asset_path = @assets[logical_path] || raise("No compiled asset for #{logical_path}, was it precompiled?")
-        asset_full_path = ::Rails.root.join("public", "assets", asset_path)
+        asset_full_path = ::Rails.root.join("public", ::Rails.application.config.assets.prefix, asset_path)
         File.read(asset_full_path)
       end
 


### PR DESCRIPTION
Enable `react-rails` to locate the YAML manifest on applications using a different `config.assets.prefix`.

Related: #594, #597