### PR TITLE
Add ability to set prerender to false when calling from controller

### DIFF
--- a/lib/react/rails/controller_renderer.rb
+++ b/lib/react/rails/controller_renderer.rb
@@ -3,7 +3,8 @@ module React
     # A renderer class suitable for `ActionController::Renderers`.
     # It is associated to `:component` in the Railtie.
     #
-    # It is prerendered with {React::ServerRendering}.
+    # It is prerendered by default with {React::ServerRendering}.
+    # Set options[:prerender] false to disable prerendering.
     #
     # @example Rendering a component from a controller
     #   class TodosController < ApplicationController
@@ -24,11 +25,20 @@ module React
         @__react_component_helper = controller.__react_component_helper
       end
 
-      # @return [String] Prerendered HTML for `component_name` with `options[:props]`
+      # @return [String] HTML for `component_name` with `options[:props]`
       def call(component_name, options, &block)
         props = options.fetch(:props, {})
-        options = options.slice(:data, :aria, :tag, :class, :id).merge(prerender: true)
+        options = options
+          .slice(:data, :aria, :tag, :class, :id, :prerender)
+          .reverse_merge(default_options)
+
         react_component(component_name, props, options, &block)
+      end
+
+      private
+
+      def default_options
+        { prerender: true }
       end
     end
   end


### PR DESCRIPTION
This change allows the `render` call in the controller to pass a `prerender` flag which overrides the default of true for a controller render.

If the React component is the only DOM rendered for a view it makes sense to render it from the controller rather than have a one-line view ERB file that calls `react_component`, and it should be possible to do this without having to force that component to be server rendered.
