### PR TITLE
Add code option to Sprockets Render

### DIFF
--- a/lib/react/server_rendering/sprockets_renderer.rb
+++ b/lib/react/server_rendering/sprockets_renderer.rb
@@ -17,6 +17,7 @@ module React
         @replay_console = options.fetch(:replay_console, true)
         filenames = options.fetch(:files, ["react-server.js", "components.js"])
         js_code = CONSOLE_POLYFILL.dup
+        js_code << options.fetch(:code, '')
 
         filenames.each do |filename|
           js_code << asset_container.find_asset(filename)

--- a/test/helper_files/WithoutSprockets.js
+++ b/test/helper_files/WithoutSprockets.js
@@ -1,0 +1,11 @@
+// compiled with Babel 6.14.0
+// const WithoutSprockets = ({label}) => <span>{label}</span>;
+
+var WithoutSprockets = function WithoutSprockets(_ref) {
+  var label = _ref.label;
+  return React.createElement(
+    "span",
+    null,
+    label
+  );
+};

--- a/test/react/server_rendering/sprockets_renderer_test.rb
+++ b/test/react/server_rendering/sprockets_renderer_test.rb
@@ -48,6 +48,14 @@ when_sprockets_available do
       assert_match(/\n/, err.to_s, "it includes the multi-line backtrace")
     end
 
+    test '.new accepts additional code to add to the JS context' do
+      additional_code = File.read(File.expand_path("../../../helper_files/WithoutSprockets.js", __FILE__))
+
+      additional_renderer = React::ServerRendering::SprocketsRenderer.new(code: additional_code)
+
+      assert_match(/drink more caffeine<\/span>/, additional_renderer.render("WithoutSprockets", {label: "drink more caffeine"}, nil))
+    end
+
     test '.new accepts any filenames' do
       limited_renderer = React::ServerRendering::SprocketsRenderer.new(files: ["react-server.js", "components/Todo.js"])
       assert_match(/get a real job<\/li>/, limited_renderer.render("Todo", {todo: "get a real job"}, nil))


### PR DESCRIPTION
This enables additional code to be added to the Exec JS context when initialised.

Our app is consuming assets generated via Sprockets and Webpack, this option allows the Webpacked assets to injected along side the Sprockets assets for use in the ExecJS runtime.