### PR TITLE
Use ['default'] property accessor, not .default

### DIFF
--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -59,8 +59,8 @@
       }
 
       // Lastly, if there is a default attribute try that
-      if (constructor && constructor.default) {
-        constructor = constructor.default;
+      if (constructor && constructor['default']) {
+        constructor = constructor['default'];
       }
 
       return constructor;


### PR DESCRIPTION
Using reserved words in dot property accessors is allowed in ES5,
but not in ES3. Android 2 throws `SyntaxError: Parse error` with `.default`