### PR TITLE
Fix broken links to babel's docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ After installing `react-rails`, restart your server. Now, `.js.jsx` files will b
 
 #### BabelTransformer options
 
-You can use babel's [transformers](http://babeljs.io/docs/advanced/transformers/) and [custom plugins](http://babeljs.io/docs/advanced/plugins/),
+You can use babel's [transformers and plugins](http://babeljs.io/docs/plugins/)
 and pass [options](http://babeljs.io/docs/usage/options/) to the babel transpiler adding following configurations:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ After installing `react-rails`, restart your server. Now, `.js.jsx` files will b
 
 #### BabelTransformer options
 
-You can use babel's [transformers and plugins](http://babeljs.io/docs/plugins/)
+You can use babel's [transformers](http://henryzoo.com/babel.github.io/docs/advanced/transformers/) and [custom plugins](http://henryzoo.com/babel.github.io/docs/advanced/plugins/),
 and pass [options](http://babeljs.io/docs/usage/options/) to the babel transpiler adding following configurations:
 
 ```ruby


### PR DESCRIPTION
The links to transformers and plugins docs page were broken after the release of Babel 6. Replaced them with links to the official legacy documentation.