### PR TITLE
Allow `camelize_props` to be passed into component mounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ MyApp::Application.configure do
 end
 ```
 
+or when mounting:
+
+```erb
+<%= react_component('HelloMessage', {name: 'John'}, {camelize_props: true}) %>
+```
+
 ### Rendering components instead of views
 
 Components can also be prerendered directly from a controller action with the custom `component` renderer. For example:

--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -24,7 +24,7 @@ module React
       # on the client.
       def react_component(name, props = {}, options = {}, &block)
         options = {:tag => options} if options.is_a?(Symbol)
-        if camelize_props_switch
+        if camelize_props_switch || options[:camelize_props]
           props = React.camelize_props(props)
         end
 
@@ -43,7 +43,7 @@ module React
         html_tag = html_options[:tag] || :div
 
         # remove internally used properties so they aren't rendered to DOM
-        html_options.except!(:tag, :prerender)
+        html_options.except!(:tag, :prerender, :camelize_props)
 
         content_tag(html_tag, '', html_options, &block)
       end

--- a/test/react/rails/component_mount_test.rb
+++ b/test/react/rails/component_mount_test.rb
@@ -24,6 +24,16 @@ when_sprockets_available do
       end
     end
 
+    test '#react_component allows camelize_props to be passed in as an option' do
+      React::Rails::ComponentMount.camelize_props_switch = false
+      helper = React::Rails::ComponentMount.new
+      html = helper.react_component('Foo', {foo_bar: 'value'}, camelize_props: true)
+      expected_props = %w(data-react-class="Foo" data-react-props="{&quot;fooBar&quot;:&quot;value&quot;}")
+      expected_props.each do |segment|
+        assert html.include?(segment)
+      end
+    end
+
     test '#react_component accepts React props with camelize_props containing nested arrays' do
       React::Rails::ComponentMount.camelize_props_switch = true
       helper = React::Rails::ComponentMount.new


### PR DESCRIPTION
This allows the use of camelize props on a case by case basis; useful if you want the option without breaking existing components