### PR TITLE
Fix react_component helper usage with a block

### DIFF
--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -18,7 +18,7 @@ module React
       # Otherwise, make a new instance.
       def react_component(*args, &block)
         helper_obj = @__react_component_helper ||= helper_implementation_class.new
-        helper_obj.react_component(*args, &block)
+        helper_obj.react_component(*args) { capture &block if block_given? }
       end
     end
   end

--- a/test/dummy/app/views/pages/_component_with_inner_html.html.erb
+++ b/test/dummy/app/views/pages/_component_with_inner_html.html.erb
@@ -1,0 +1,3 @@
+<%= react_component 'GreetingMessage', { :name => 'Name' }, { :id => 'component' } do %>
+  <div id="unique-nested-id">NestedContent</div>
+<% end %>

--- a/test/react/rails/view_helper_test.rb
+++ b/test/react/rails/view_helper_test.rb
@@ -2,7 +2,10 @@ require "test_helper"
 
 # Provide direct access to the view helper methods
 class ViewHelperHelper
+  extend ActionView::Context
+  extend ActionView::Helpers::CaptureHelper
   extend React::Rails::ViewHelper
+
 end
 
 class ViewHelperTest < ActionView::TestCase
@@ -12,11 +15,30 @@ class ViewHelperTest < ActionView::TestCase
     assert_equal(expected_html, rendered_html)
   end
 
+  test 'view helper accepts block usage' do
+    expected_html = %{<div data-react-class="Component" data-react-props="{&quot;a&quot;:&quot;b&quot;}">content</div>}
+    rendered_html = ViewHelperHelper.react_component("Component", {a: "b"}) do
+      "content"
+    end
+    assert_equal(expected_html, rendered_html)
+  end
+
   test "view helper can be used in stand-alone views" do
     @name = "React-Rails"
     render template: "pages/show"
     assert_includes(rendered, "React-Rails")
   end
+
+  test "view helper can accept block and render inner content only once" do
+    rendered_html = render partial: "pages/component_with_inner_html"
+    expected_html = <<HTML
+<div data-react-class=\"GreetingMessage\" data-react-props=\"{&quot;name&quot;:&quot;Name&quot;}\" id=\"component\">
+  <div id=\"unique-nested-id\">NestedContent</div>
+</div>
+HTML
+    assert_equal expected_html.strip, rendered_html
+  end
+
 
   test "view helper uses the implementation class set in the initializer" do
     assert_equal(


### PR DESCRIPTION
Capture block output to prevent double rendering.
references #640