### PR TITLE
feat(ComponentMount) allow overriding camelize_props=true with local false

### DIFF
--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -24,7 +24,7 @@ module React
       # on the client.
       def react_component(name, props = {}, options = {}, &block)
         options = {:tag => options} if options.is_a?(Symbol)
-        if camelize_props_switch || options[:camelize_props]
+        if options.fetch(:camelize_props, camelize_props_switch)
           props = React.camelize_props(props)
         end
 

--- a/test/react/rails/component_mount_test.rb
+++ b/test/react/rails/component_mount_test.rb
@@ -32,6 +32,14 @@ when_sprockets_available do
       expected_props.each do |segment|
         assert html.include?(segment)
       end
+
+      React::Rails::ComponentMount.camelize_props_switch = true
+      helper = React::Rails::ComponentMount.new
+      html = helper.react_component('Foo', {foo_bar: 'value'}, camelize_props: false)
+      expected_props = %w(data-react-class="Foo" data-react-props="{&quot;foo_bar&quot;:&quot;value&quot;}")
+      expected_props.each do |segment|
+        assert html.include?(segment)
+      end
     end
 
     test '#react_component accepts React props with camelize_props containing nested arrays' do


### PR DESCRIPTION
A new feature in #642 was to pass `camelize_props: true` to override the default of `false`

This adds the ability to `camelize_props: false` to override the default of `true`.