### PR TITLE
Add link to free React on Rails course in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Any subclass of `ExecJSRenderer` may use those hooks (for example, `SprocketsRen
 - [Ruby Hyperloop](http://ruby-hyperloop.io/): Use Ruby to build reactive user interfaces with React.
 - [react-rails-hot-loader](https://github.com/rmosolgo/react-rails-hot-loader) is a simple live-reloader for `react-rails`.
 - [react-rails-benchmark_renderer](https://github.com/pboling/react-rails-benchmark_renderer) adds performance instrumentation to server rendering.
+- [The Free React on Rails Course](https://learnetto.com/users/hrishio/courses/the-free-react-on-rails-5-course) A free video course which teaches the basics of React and how to get started using it in Rails with `react-rails`.
 
 ## Development
 


### PR DESCRIPTION
Add a link to the free React on Rails course (https://learnetto.com/users/hrishio/courses/the-free-react-on-rails-5-course) to the Related Projects section in the README, as per email discussion with @rmosolgo.