### PR TITLE
remove coffee-script-source from dependency

### DIFF
--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'turbolinks', '>= 2.0.0'
   s.add_development_dependency 'rails', '>= 3.2'
 
-  s.add_dependency 'coffee-script-source', '~>1.8'
   s.add_dependency 'connection_pool'
   s.add_dependency 'execjs'
   s.add_dependency 'railties', '>= 3.2'


### PR DESCRIPTION
coffee-script-source is not required to use this gem, so remove it from dependency.