### PR TITLE
feat(ServerRendering) reload when new files are added; support configurable reloader globs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ MyApp::Application.configure do
     files: ["server_rendering.js"],       # files to load for prerendering
     replay_console: true,                 # if true, console.* will be replayed client-side
   }
+  # Changing files matching these dirs/exts will cause the server renderer to reload:
+  config.react.server_renderer_extensions = ["jsx"]
+  config.react.server_renderer_directories = ["/app/assets/javascripts"]
 end
 ```
 

--- a/test/server_rendered_html_test.rb
+++ b/test/server_rendered_html_test.rb
@@ -37,6 +37,27 @@ when_sprockets_available do
       end
     end
 
+    test 'it reloads when new jsx files are added' do
+      begin
+        get '/server/1'
+        refute_match(/Overwritten List/, response.body)
+
+        # Make it alphabetically last so it will override the preceeding one:
+        new_file_path = File.expand_path('../dummy/app/assets/javascripts/components/ZZ_NewComponent.js.jsx', __FILE__)
+        File.write new_file_path, <<-JS
+        var TodoList = function() { return <span>"Overwritten List"</span> }
+        JS
+
+        wait_to_ensure_asset_pipeline_detects_changes
+
+        get '/server/1'
+        assert_match(/Overwritten List/, response.body)
+      ensure
+        FileUtils.rm_rf(new_file_path)
+        wait_to_ensure_asset_pipeline_detects_changes
+      end
+    end
+
     test 'react server rendering shows console output as html comment' do
       # Make sure console messages are replayed when requested
       get '/server/console_example'


### PR DESCRIPTION
Using `FileUpdateChecker` will catch new files too, and we can expose an API for watching _any_ files (spoiler alert, I'm going to use this for webpacker 😆 )