### PR TITLE
Fix console replay

### DIFF
--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -46,7 +46,15 @@ module React
         # remove internally used properties so they aren't rendered to DOM
         html_options.except!(:tag, :prerender, :camelize_props)
 
-        content_tag(html_tag, '', html_options, &block)
+        rendered_tag = content_tag(html_tag, '', html_options, &block)
+        if React::ServerRendering.renderer_options[:replay_console]
+          # Grab the server-rendered console replay script
+          # and move it _outside_ the container div
+          rendered_tag.sub!(/\n(<script class="react-rails-console-replay">.*<\/script>)<\/(\w+)>$/m,'</\2>\1')
+          rendered_tag.html_safe
+        else
+          rendered_tag
+        end
       end
 
       private

--- a/lib/react/server_rendering.rb
+++ b/lib/react/server_rendering.rb
@@ -7,6 +7,8 @@ module React
     mattr_accessor :renderer, :renderer_options,
       :pool_size, :pool_timeout
 
+    self.renderer_options = {}
+
     # Discard the old ConnectionPool & create a new one
     def self.reset_pool
       options = {size: pool_size, timeout: pool_timeout}

--- a/lib/react/server_rendering/bundle_renderer/console_replay.js
+++ b/lib/react/server_rendering/bundle_renderer/console_replay.js
@@ -1,6 +1,6 @@
 (function (history) {
   if (history && history.length > 0) {
-    result += '\n<scr'+'ipt>';
+    result += '\n<scr'+'ipt class="react-rails-console-replay">';
     history.forEach(function (msg) {
       result += '\nconsole.' + msg.level + '.apply(console, ' + JSON.stringify(msg.arguments) + ');';
     });

--- a/test/dummy/app/javascript/components/TodoList.js
+++ b/test/dummy/app/javascript/components/TodoList.js
@@ -8,6 +8,7 @@ module.exports = React.createClass({
     this.setState({mounted: 'yep'});
   },
   render: function() {
+    console.log("Test Console Replay")
     return (
       <ul>
         <li id='status'>{this.state.mounted}</li>

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -32,6 +32,10 @@ module Dummy
     # config.i18n.default_locale = :de
     config.react.variant = :production
     config.react.addons = false
+    config.react.server_renderer_options = {
+      replay_console: true,
+    }
+
     if SprocketsHelpers.available?
       config.assets.enabled = true
     end

--- a/test/react/server_rendering/bundle_renderer_test.rb
+++ b/test/react/server_rendering/bundle_renderer_test.rb
@@ -49,7 +49,7 @@ if SprocketsHelpers.available? || WebpackerHelpers.available?
 
     test '#render replays console messages' do
       result = @renderer.render("TodoListWithConsoleLog", {todos: ["log some messages"]}, nil)
-      assert_match(/<script>$/, result)
+      assert_match(/<script class="react-rails-console-replay">$/, result)
       assert_match(/console.log.apply\(console, \["got initial state"\]\);$/, result)
       assert_match(/console.warn.apply\(console, \["mounted component"\]\);$/, result)
       assert_match(/console.error.apply\(console, \["rendered!","foo"\]\);$/, result)


### PR DESCRIPTION
Fix #555 

If the console replay script is present in the mount tag, move it _outside_ the tag so that React doesn't complain when re-rendering inside the mount tag.