### PR TITLE
fix(UJS) support cases when Turbolinks is loaded after UJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,14 @@ You can use this when the DOM is modified by AJAX calls or modal windows.
 
 `ReactRailsUJS` will automatically mount components on `<%= react_component(...) %>` tags and unmount them when appropriate.
 
-Be sure to load `react_ujs` _after_ these libraries so that it can detect them.
+If you need to re-detect events, you can call `detectEvents`:
+
+```js
+// Remove previous event handlers and add new ones:
+ReactRailsUJS.detectEvents()
+```
+
+For example, if `Turbolinks` is loaded _after_ `ReactRailsUJS`, you'll need to call this again. This function removes previous handlers before adding new ones, so it's safe to call as often as needed.
 
 ### `getConstructor`
 

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -105,11 +105,36 @@ var ReactRailsUJS = {
       ReactDOM.unmountComponentAtNode(node);
     }
   },
+
+  // Check the global context for installed libraries
+  // and figure out which library to hook up to (pjax, Turbolinks, jQuery)
+  // This is called on load, but you can call it again if needed
+  // (It will unmount itself)
+  detectEvents: function() {
+    detectEvents(this)
+  },
 }
+
+// These stable references are so that handlers can be added and removed:
+ReactRailsUJS.handleMount = function(e) {
+  var target = undefined;
+  if (e && e.target) {
+    target = e.target;
+  }
+  ReactRailsUJS.mountComponents(target);
+}
+ReactRailsUJS.handleUnmount = function(e) {
+  var target = undefined;
+  if (e && e.target) {
+    target = e.target;
+  }
+  ReactRailsUJS.unmountComponents(target);
+}
+
 
 if (typeof window !== "undefined") {
   // Only setup events for browser (not server-rendering)
-  detectEvents(ReactRailsUJS)
+  ReactRailsUJS.detectEvents()
 }
 
 // It's a bit of a no-no to populate the global namespace,

--- a/react_ujs/src/events/detect.js
+++ b/react_ujs/src/events/detect.js
@@ -7,13 +7,36 @@ var turbolinksClassicEvents = require("./turbolinksClassic")
 // see what things are globally available
 // and setup event handlers to those things
 module.exports = function(ujs) {
+  console.log(ujs.handleEvent)
+  if (ujs.handleEvent) {
+    // We're calling this a second time -- remove previous handlers
+    turbolinksClassicEvents.teardown(ujs)
+    turbolinksEvents.teardown(ujs);
+    turbolinksClassicDeprecatedEvents.teardown(ujs);
+    pjaxEvents.teardown(ujs);
+    nativeEvents.teardown(ujs);
+  }
+
   if (ujs.jQuery) {
     ujs.handleEvent = function(eventName, callback) {
       ujs.jQuery(document).on(eventName, callback);
     };
-  } else {
+    ujs.removeEvent = function(eventName, callback) {
+      ujs.jQuery(document).off(eventName, callback);
+    }
+  } else if ('addEventListener' in window) {
     ujs.handleEvent = function(eventName, callback) {
       document.addEventListener(eventName, callback);
+    };
+    ujs.removeEvent = function(eventName, callback) {
+      document.removeEventListener(eventName, callback);
+    };
+  } else {
+    ujs.handleEvent = function(eventName, callback) {
+      window.attachEvent(eventName, callback);
+    };
+    ujs.removeEvent = function(eventName, callback) {
+      window.detachEvent(eventName, callback);
     };
   }
 

--- a/react_ujs/src/events/native.js
+++ b/react_ujs/src/events/native.js
@@ -4,12 +4,18 @@ module.exports = {
   setup: function(ujs) {
     if (ujs.jQuery) {
       // Use jQuery if it's present:
-      ujs.jQuery(function() { ujs.mountComponents() });
+      ujs.handleEvent("ready", ujs.handleMount);
     } else if ('addEventListener' in window) {
-      document.addEventListener('DOMContentLoaded', function() { ujs.mountComponents() });
+      ujs.handleEvent('DOMContentLoaded', ujs.handleMount);
     } else {
       // add support to IE8 without jQuery
-      window.attachEvent('onload', function() { ujs.mountComponents() });
+      ujs.handleEvent('onload', ujs.handleMount);
     }
+  },
+
+  teardown: function(ujs) {
+    ujs.removeEvent("ready", ujs.handleMount);
+    ujs.removeEvent('DOMContentLoaded', ujs.handleMount);
+    ujs.removeEvent('onload', ujs.handleMount);
   }
 }

--- a/react_ujs/src/events/pjax.js
+++ b/react_ujs/src/events/pjax.js
@@ -1,8 +1,14 @@
 module.exports = {
   // pjax support
   setup: function(ujs) {
-    ujs.handleEvent('ready', function() { ujs.mountComponents() });
-    ujs.handleEvent('pjax:end', function(e) { ujs.mountComponents(e.target) });
-    ujs.handleEvent('pjax:beforeReplace', function(e) { ujs.unmountComponents(e.target) });
-  }
+    ujs.handleEvent('ready', ujs.handleMount);
+    ujs.handleEvent('pjax:end', ujs.handleMount);
+    ujs.handleEvent('pjax:beforeReplace', ujs.handleUnmount);
+  },
+
+  teardown: function(ujs) {
+    ujs.removeEvent('ready', ujs.handleMount);
+    ujs.removeEvent('pjax:end', ujs.handleMount);
+    ujs.removeEvent('pjax:beforeReplace', ujs.handleUnmount);
+  },
 }

--- a/react_ujs/src/events/turbolinks.js
+++ b/react_ujs/src/events/turbolinks.js
@@ -1,8 +1,14 @@
 module.exports = {
   // Turbolinks 5+ got rid of named events (?!)
   setup: function(ujs) {
-    ujs.handleEvent('DOMContentLoaded', function() { ujs.mountComponents() })
-    ujs.handleEvent('turbolinks:render', function() { ujs.mountComponents() })
-    ujs.handleEvent('turbolinks:before-render', function() { ujs.unmountComponents() })
+    ujs.handleEvent('DOMContentLoaded', ujs.handleMount)
+    ujs.handleEvent('turbolinks:render', ujs.handleMount)
+    ujs.handleEvent('turbolinks:before-render', ujs.handleUnmount)
+  },
+
+  teardown: function(ujs) {
+    ujs.removeEvent('DOMContentLoaded', ujs.handleMount)
+    ujs.removeEvent('turbolinks:render', ujs.handleMount)
+    ujs.removeEvent('turbolinks:before-render', ujs.handleUnmount)
   },
 }

--- a/react_ujs/src/events/turbolinksClassic.js
+++ b/react_ujs/src/events/turbolinksClassic.js
@@ -2,7 +2,11 @@ module.exports = {
   // Attach handlers to Turbolinks-Classic events
   // for mounting and unmounting components
   setup: function(ujs) {
-    ujs.handleEvent(Turbolinks.EVENTS.CHANGE, function() { ujs.mountComponents() });
-    ujs.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, function() { ujs.unmountComponents() });
+    ujs.handleEvent(Turbolinks.EVENTS.CHANGE, ujs.handleMount);
+    ujs.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, ujs.handleUnmount);
+  },
+  teardown: function(ujs) {
+    ujs.removeEvent(Turbolinks.EVENTS.CHANGE, ujs.handleMount);
+    ujs.removeEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, ujs.handleUnmount);
   }
 }

--- a/react_ujs/src/events/turbolinksClassicDeprecated.js
+++ b/react_ujs/src/events/turbolinksClassicDeprecated.js
@@ -5,7 +5,11 @@ module.exports = {
   // https://github.com/reactjs/react-rails/issues/87
   setup: function(ujs) {
     Turbolinks.pagesCached(0)
-    ujs.handleEvent('page:change', function() { ujs.mountComponents() });
-    ujs.handleEvent('page:receive', function() { ujs.unmountComponents() });
+    ujs.handleEvent('page:change', ujs.handleMount);
+    ujs.handleEvent('page:receive', ujs.handleUnmount);
+  },
+  teardown: function(ujs) {
+    ujs.removeEvent('page:change', ujs.handleMount);
+    ujs.removeEvent('page:receive', ujs.handleUnmount);
   }
 }

--- a/react_ujs/yarn.lock
+++ b/react_ujs/yarn.lock
@@ -993,8 +993,8 @@ ms@0.7.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
 nan@^2.3.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.1.tgz#8c84f7b14c96b89f57fbc838012180ec8ca39a01"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
 node-libs-browser@^2.0.0:
   version "2.0.0"
@@ -1425,8 +1425,8 @@ spdx-license-ids@^1.0.2:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
 sshpk@^1.7.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.11.0.tgz#2d8d5ebb4a6fab28ffba37fa62a90f4a3ea59d77"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.0.tgz#ff2a3e4fd04497555fed97b39a0fd82fafb3a33c"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"

--- a/test/dummy/package.json
+++ b/test/dummy/package.json
@@ -21,7 +21,7 @@
     "rails-erb-loader": "^4.0.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react_ujs": "^0.3.0",
+    "react_ujs": "^1.0.0",
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",
     "webpack": "^2.3.3",

--- a/test/dummy/yarn.lock
+++ b/test/dummy/yarn.lock
@@ -3450,9 +3450,9 @@ react@^15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-react_ujs@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react_ujs/-/react_ujs-0.3.0.tgz#078298dca3116b813b6813419b4825c6e2b5b57f"
+react_ujs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react_ujs/-/react_ujs-1.0.0.tgz#33fbae8cd949fbdd28914d7a0b69bf3c078aa4be"
 
 read-cache@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Oops, I discovered a circular dependency issue when upgrading my app to 2.0: 

- My sprockets bundle depends on my webpacker pack because the pack assigns `window.React`. 
- My webpacker pack has `require("react_ujs")` which checks the global context for events 
- At that time, Turbolinks is not present, so its events are not hooked up by UJS 
- For that reason, the webpacker pack depends on my sprockets bundle 😩 

With this branch, you can re-detect events at any time with `detectEvents()`. 

This way, I can add:

```js
$(function() {
  // Now that turbolinks is loaded, hook up to it:
  ReactRailsUJS.detectEvents()
})
```