### PR TITLE
fix(ReactUjs): Fixed variable typo in findDOMNodes

### DIFF
--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -238,7 +238,7 @@ var ReactRailsUJS = {
 
   // helper method for the mount and unmount methods to find the
   // `data-react-class` DOM elements
-  findDOMNodes: function(selector) {
+  findDOMNodes: function(searchSelector) {
     var classNameAttr = ReactRailsUJS.CLASS_NAME_ATTR
     // we will use fully qualified paths as we do not bind the callbacks
     var selector, parent;

--- a/react_ujs/dist/react_ujs.js
+++ b/react_ujs/dist/react_ujs.js
@@ -238,7 +238,7 @@ var ReactRailsUJS = {
 
   // helper method for the mount and unmount methods to find the
   // `data-react-class` DOM elements
-  findDOMNodes: function(selector) {
+  findDOMNodes: function(searchSelector) {
     var classNameAttr = ReactRailsUJS.CLASS_NAME_ATTR
     // we will use fully qualified paths as we do not bind the callbacks
     var selector, parent;

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -20,7 +20,7 @@ var ReactRailsUJS = {
 
   // helper method for the mount and unmount methods to find the
   // `data-react-class` DOM elements
-  findDOMNodes: function(selector) {
+  findDOMNodes: function(searchSelector) {
     var classNameAttr = ReactRailsUJS.CLASS_NAME_ATTR
     // we will use fully qualified paths as we do not bind the callbacks
     var selector, parent;

--- a/test/dummy/app/views/pages/show.html.erb
+++ b/test/dummy/app/views/pages/show.html.erb
@@ -1,10 +1,13 @@
 <ul>
-  <li><%= link_to 'Alice', page_path(:id => 0) %></li>
-  <li><%= link_to 'Bob', page_path(:id => 1) %></li>
+  <li><%= link_to 'Alice', page_path(id: 0) %></li>
+  <li><%= link_to 'Bob', page_path(id: 1) %></li>
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { :name => @name }, { :id => 'component', prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name }, { id: 'component', prerender: @prerender } %>
+  <ul>
+    <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
+  </ul>
 </div>
 
 <button onClick="ReactRailsUJS.unmountComponents('#component-parent')">Unmount by parent selector</button>

--- a/test/react/rails/controller_lifecycle_test.rb
+++ b/test/react/rails/controller_lifecycle_test.rb
@@ -46,7 +46,7 @@ class ControllerLifecycleTest < ActionDispatch::IntegrationTest
   test "it calls setup and teardown methods" do
     get '/pages/1?param_test=123'
     helper_obj = controller.__react_component_helper
-    lifecycle_steps = ["123", :react_component, :teardown]
+    lifecycle_steps = ["123", :react_component, :react_component, :teardown]
     assert_equal(lifecycle_steps, helper_obj.events)
   end
 

--- a/test/react/rails/react_rails_ujs_test.rb
+++ b/test/react/rails/react_rails_ujs_test.rb
@@ -124,6 +124,21 @@ SprocketsHelpers.when_available do
       assert_greeting(page, 'Hello Bob')
     end
 
+    test 'react_ujs does not unmount components that do not match a selector reference for the component' do
+      visit '/pages/1'
+      assert_greeting page, 'Hello Bob'
+      assert page.has_content?('Another Component'), page.body
+
+      page.click_button "Unmount by own selector"
+      refute_greeting(page, 'Hello Bob')
+      assert page.has_content?('Another Component'), page.body
+
+      page.click_button "Mount by own selector"
+      assert_greeting(page, 'Hello Bob')
+      assert page.has_content?('Another Component'), page.body
+    end
+
+
     test 'react_ujs can unmount/mount using a dom node context' do
       visit '/pages/1'
       assert_greeting(page, 'Hello Bob')


### PR DESCRIPTION
### Why this was needed
 Looks like `findDOMNodes` has a typo in the argument name [here](https://github.com/reactjs/react-rails/blob/master/react_ujs/index.js#L23). `selector` should be `searchSelector`. Since the incorrect value is used ALL components are unmounted when `findDOMNodes` is called from [unmountComponents](https://github.com/reactjs/react-rails/blob/master/react_ujs/index.js#L100)

### How I fixed it
Updated argument name from `selector` to `searchSelector` [here](https://github.com/tannermares/react-rails/blob/4f65848239fd6665d8c4a8aa5878103764d83e11/react_ujs/index.js#L23)

I adding a spec. I'm not familiar with MiniTest or server side rendering and tried to implement the failure in the simplest way possible.

I believe the failing specs are from JS warnings the `rake react:update` caused. Looks like maybe the `createClass` deprecation? Should I not `rake react:update`?

Any suggestions on that front and I'll gladly implement. :)

> Note: This is my first contribution and couldn't find a "how to contribute" section. I apologize for any missing steps or documentation.