### PR TITLE
check for turbolinks classic before teardown

### DIFF
--- a/react_ujs/src/events/detect.js
+++ b/react_ujs/src/events/detect.js
@@ -9,7 +9,9 @@ var turbolinksClassicEvents = require("./turbolinksClassic")
 module.exports = function(ujs) {
   if (ujs.handleEvent) {
     // We're calling this a second time -- remove previous handlers
-    turbolinksClassicEvents.teardown(ujs)
+    if (typeof Turbolinks.EVENTS !== "undefined") {
+      turbolinksClassicEvents.teardown(ujs);
+    }
     turbolinksEvents.teardown(ujs);
     turbolinksClassicDeprecatedEvents.teardown(ujs);
     pjaxEvents.teardown(ujs);


### PR DESCRIPTION
When using Turbolinks 5+, `ReactRailsUJS.detectEvents()` throws the following error when  removing the existing event handlers:
```
Uncaught TypeError: Cannot read property 'CHANGE' of undefined
    at Object.teardown (turbolinksClassic.js?6757:9)
    at module.exports (detect.js?5263:12)
    at Object.detectEvents (index.js?c0e8:114)
```
Since Turbolinks 5 doesn't define `Turbolinks.EVENTS`, we can check for its existence before calling the classic teardown method.