### PR TITLE
Configure watched files after rails initializers have loaded

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -24,7 +24,7 @@ module React
       config.react.view_helper_implementation = nil # Defaults to ComponentMount
 
       # Watch .jsx files for changes in dev, so we can reload the JS VMs with the new JS code.
-      initializer "react_rails.add_watchable_files", group: :all do |app|
+      initializer "react_rails.add_watchable_files", after: :load_config_initializers, group: :all do |app|
         # Watch files ending in `server_renderer_extensions` in each of `server_renderer_directories`
         reload_paths = config.react.server_renderer_directories.reduce({}) do |memo, dir|
           app_dir = File.join(app.root, dir)

--- a/test/dummy/app/pants/yfronts.js
+++ b/test/dummy/app/pants/yfronts.js
@@ -1,0 +1,1 @@
+// used for testing file watcher configuration

--- a/test/dummy/config/initializers/react.rb
+++ b/test/dummy/config/initializers/react.rb
@@ -5,5 +5,10 @@ end
 Dummy::Application.configure do
   config.react.addons = true
   config.react.view_helper_implementation = CustomComponentMount
+  # Add "app/pants" to the array we can test that file watchers are setup after
+  # rails initializers are loaded
+  config.react.server_renderer_directories = ["/app/assets/javascripts/",
+                                              "app/javascript",
+                                              "app/pants"]
 end
 

--- a/test/react/rails/railtie_test.rb
+++ b/test/react/rails/railtie_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class RailtieTest < ActionDispatch::IntegrationTest
+  test "reloaders are configured after initializers are loaded" do
+    @test_file = File.expand_path("../../dummy/app/pants/yfronts.js", File.dirname(__FILE__))
+    FileUtils.touch @test_file
+    results = Dummy::Application.reloaders.map(&:updated?)
+    assert_includes(results, true)
+  end
+end


### PR DESCRIPTION
Rails convention is now to load application config from initializers rather than `config/application.rb`. This PR makes it possible to specify`server_renderer_directories` (amongst other settings) and have the settings honoured by the file watcher. Previously some settings configured in an initializer were ignored as the file watcher block was run before initializers were loaded.