### PR TITLE
Fix #758 - Find .jsx component files

### DIFF
--- a/react_ujs/src/getConstructor/fromRequireContext.js
+++ b/react_ujs/src/getConstructor/fromRequireContext.js
@@ -10,7 +10,12 @@ module.exports = function(reqctx) {
     var filename = parts.shift()
     var keys = parts
     // Load the module:
-    var component = reqctx("./" + filename)
+    var component;
+    try {
+      component = reqctx("./" + filename)
+    } catch(err) {
+      component = reqctx("./" + filename + ".jsx")
+    }
     // Then access each key:
     keys.forEach(function(k) {
       component = component[k]


### PR DESCRIPTION
If the original `fileName` search doesn't work, look for the file with `.jsx` on the end. This makes it possible to include `.jsx` files in the `app/javascript/components` directory and have `react-rails` find them automatically, importing their components.