### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ $ rails g react:install
 Get started by adding `webpacker` to your gemfile and installing `webpacker` and `react-rails`:
 
 ```
-$ rails webpacker:install
-$ rails webpacker:install:react
-$ rails generate react:install
+$ rake webpacker:install
+$ rake webpacker:install:react
+$ rake generate react:install
 ```
 
 This gives you:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Get started by adding `webpacker` to your gemfile and installing `webpacker` and
 ```
 $ rake webpacker:install
 $ rake webpacker:install:react
-$ rake generate react:install
+$ rails generate react:install
 ```
 
 This gives you:


### PR DESCRIPTION
The webpacker installation commands were prepended with `rails` when I believe it should have been `rake`