### PR TITLE
Webpack API changes

### DIFF
--- a/lib/generators/react/install_generator.rb
+++ b/lib/generators/react/install_generator.rb
@@ -60,8 +60,8 @@ module React
 
       def javascript_dir
         if webpacker?
-          Webpacker::Configuration.source_path
-            .join(Webpacker::Configuration.entry_path)
+          Webpacker.config.source_path
+            .join(Webpacker.config.entry_path)
             .relative_path_from(::Rails.root)
             .to_s
         else

--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -12,7 +12,7 @@ module React
 
       def find_asset(logical_path)
         # raises if not found
-        asset_path = Webpacker::Manifest.lookup(logical_path).to_s
+        asset_path = Webpacker.manifest.lookup(logical_path).to_s
         if asset_path.start_with?("http")
           # Get a file from the webpack-dev-server
           dev_server_asset = open(asset_path).read
@@ -21,7 +21,7 @@ module React
           dev_server_asset
         else
           # Read the already-compiled pack:
-          full_path = Webpacker::Manifest.lookup_path(logical_path).to_s
+          full_path = ::Rails.root.join(File.join(Webpacker.config.public_path, Webpacker.manifest.lookup(logical_path))).to_s
           File.read(full_path)
         end
       end


### PR DESCRIPTION
Webpack has changed their public API in this PR:
https://github.com/rails/webpacker/pull/636

This PR allows `react-rails` to work with the latest webpacker version.

fixes: https://github.com/reactjs/react-rails/issues/778, https://github.com/reactjs/react-rails/issues/776