### PR TITLE
Cleanup tests, fix a broken test seed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 rvm:
   - 2.3.0
   - 2.1
-  - jruby-9.0.1.0
+  - jruby-9.1.9.0
 
 gemfile:
   # These have webpacker:
@@ -53,27 +53,27 @@ matrix:
       gemfile: gemfiles/rails_5_no_sprockets.gemfile
     - rvm: 2.1
       gemfile: gemfiles/rails_5.1_sprockets_4.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_4.0.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: rails_4.0_with_therubyracer.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_4.2_sprockets_2.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_5_no_sprockets_webpacker_1_1.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_5_no_sprockets_webpacker_1_x.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_5_no_sprockets_webpacker_2.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_5_no_sprockets_webpacker_3.gemfile
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails_5_no_sprockets.gemfile
 
   allow_failures:
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.9.0
 
 before_install:
   - nvm install 7.8.0 && nvm use 7.8.0

--- a/Appraisals
+++ b/Appraisals
@@ -17,7 +17,7 @@ end
 
 appraise 'rails-4.0-with-therubyracer' do
   gem 'rails', '~> 4.0.13'
-  gem 'therubyracer', '0.12.0', :platform => :mri
+  gem 'therubyracer', '0.12.0', :platforms => :mri
   gem 'turbolinks'
 end
 
@@ -45,7 +45,8 @@ appraise 'rails-4.2-sprockets_4' do
   gem 'turbolinks', '~> 2.5.0'
   # This ExecJS backend provides stateful context
   # which the default nodejs backend does not
-  gem 'mini_racer'
+  gem 'mini_racer', :platforms => :mri
+  gem 'therubyrhino', :platforms => :jruby
 end
 
 # no_sprockets is a magical name from sprockets_helper.rb in test to
@@ -55,7 +56,8 @@ appraise 'rails-5_no_sprockets_webpacker_1_1' do
   gem 'webpacker', '~> 1.1.0'
   # This ExecJS backend provides stateful context
   # which the default nodejs backend does not
-  gem 'therubyracer'
+  gem 'therubyracer', :platforms => :mri
+  gem 'therubyrhino', :platforms => :jruby
 end
 
 appraise 'rails-5_no_sprockets_webpacker_1_x' do
@@ -63,7 +65,8 @@ appraise 'rails-5_no_sprockets_webpacker_1_x' do
   gem 'webpacker', '~> 1.2'
   # This ExecJS backend provides stateful context
   # which the default nodejs backend does not
-  gem 'therubyracer'
+  gem 'therubyracer', :platforms => :mri
+  gem 'therubyrhino', :platforms => :jruby
 end
 
 appraise 'rails-5_no_sprockets_webpacker_2' do
@@ -71,7 +74,8 @@ appraise 'rails-5_no_sprockets_webpacker_2' do
   gem 'webpacker', '~> 2.0'
   # This ExecJS backend provides stateful context
   # which the default nodejs backend does not
-  gem 'therubyracer'
+  gem 'therubyracer', :platforms => :mri
+  gem 'therubyrhino', :platforms => :jruby
 end
 
 appraise 'rails-5_no_sprockets_webpacker_3' do
@@ -79,7 +83,8 @@ appraise 'rails-5_no_sprockets_webpacker_3' do
   gem 'webpacker', '>= 3.0'
   # This ExecJS backend provides stateful context
   # which the default nodejs backend does not
-  gem 'therubyracer'
+  gem 'therubyracer', :platforms => :mri
+  gem 'therubyrhino', :platforms => :jruby
 end
 
 appraise 'rails-5-no_sprockets' do

--- a/Appraisals
+++ b/Appraisals
@@ -46,7 +46,6 @@ appraise 'rails-4.2-sprockets_4' do
   # This ExecJS backend provides stateful context
   # which the default nodejs backend does not
   gem 'mini_racer', :platforms => :mri
-  gem 'therubyrhino', :platforms => :jruby
 end
 
 # no_sprockets is a magical name from sprockets_helper.rb in test to

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -6,4 +6,4 @@ gem "rails", "~> 3.2.21"
 gem "rack-cache", "~> 1.6.1"
 gem "turbolinks", "~> 2.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.0.5.gemfile
+++ b/gemfiles/rails_4.0.5.gemfile
@@ -5,4 +5,4 @@ source "http://rubygems.org"
 gem "rails", "4.0.5"
 gem "turbolinks"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.0_with_therubyracer.gemfile
+++ b/gemfiles/rails_4.0_with_therubyracer.gemfile
@@ -3,7 +3,7 @@
 source "http://rubygems.org"
 
 gem "rails", "~> 4.0.13"
-gem "therubyracer", "0.12.0", :platform => :mri
+gem "therubyracer", "0.12.0", platforms: :mri
 gem "turbolinks"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -5,4 +5,4 @@ source "http://rubygems.org"
 gem "rails", "~> 4.1.10"
 gem "turbolinks", "~> 2.3.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.2_sprockets_2.gemfile
+++ b/gemfiles/rails_4.2_sprockets_2.gemfile
@@ -6,4 +6,4 @@ gem "rails", "~> 4.2.1"
 gem "sprockets", "~> 2.12"
 gem "turbolinks"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.2_sprockets_3.gemfile
+++ b/gemfiles/rails_4.2_sprockets_3.gemfile
@@ -6,4 +6,4 @@ gem "rails", "~> 4.2.1"
 gem "sprockets", "~> 3.5"
 gem "turbolinks", "~> 2.5.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.2_sprockets_4.gemfile
+++ b/gemfiles/rails_4.2_sprockets_4.gemfile
@@ -5,6 +5,7 @@ source "http://rubygems.org"
 gem "rails", "~> 4.2.1"
 gem "sprockets", "~> 4.0.x"
 gem "turbolinks", "~> 2.5.0"
-gem "mini_racer"
+gem "mini_racer", platforms: :mri
+gem "therubyrhino", platforms: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.2_sprockets_4.gemfile
+++ b/gemfiles/rails_4.2_sprockets_4.gemfile
@@ -6,6 +6,5 @@ gem "rails", "~> 4.2.1"
 gem "sprockets", "~> 4.0.x"
 gem "turbolinks", "~> 2.5.0"
 gem "mini_racer", platforms: :mri
-gem "therubyrhino", platforms: :jruby
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1_sprockets_4.gemfile
+++ b/gemfiles/rails_5.1_sprockets_4.gemfile
@@ -6,4 +6,4 @@ gem "rails", "~> 5.1"
 gem "sprockets", "~> 4.0.x"
 gem "turbolinks", "~> 5.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_no_sprockets.gemfile
+++ b/gemfiles/rails_5_no_sprockets.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_no_sprockets_webpacker_1_1.gemfile
+++ b/gemfiles/rails_5_no_sprockets_webpacker_1_1.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 gem "webpacker", "~> 1.1.0"
-gem "therubyracer"
+gem "therubyracer", platforms: :mri
+gem "therubyrhino", platforms: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_no_sprockets_webpacker_1_x.gemfile
+++ b/gemfiles/rails_5_no_sprockets_webpacker_1_x.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 gem "webpacker", "~> 1.2"
-gem "therubyracer"
+gem "therubyracer", platforms: :mri
+gem "therubyrhino", platforms: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_no_sprockets_webpacker_2.gemfile
+++ b/gemfiles/rails_5_no_sprockets_webpacker_2.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 gem "webpacker", "~> 2.0"
-gem "therubyracer"
+gem "therubyracer", platforms: :mri
+gem "therubyrhino", platforms: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_no_sprockets_webpacker_3.gemfile
+++ b/gemfiles/rails_5_no_sprockets_webpacker_3.gemfile
@@ -4,6 +4,7 @@ source "http://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 gem "webpacker", ">= 3.0"
-gem "therubyracer"
+gem "therubyracer", platforms: :mri
+gem "therubyrhino", platforms: :jruby
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/test/react/rails/pages_controller_test.rb
+++ b/test/react/rails/pages_controller_test.rb
@@ -13,16 +13,16 @@ class PagesControllerTest < ActionController::TestCase
 
   when_stateful_js_context_available do
     test 'it sets up and tears down a react context' do
-      get :show, params: { id: 1, prerender: true }
+      get :show, id: 1, prerender: true
       assert_includes(response.body, 'Hello')
 
-      get :show, params: { id: 1, prerender: true, greeting: 'Howdy' }
+      get :show, id: 1, prerender: true, greeting: 'Howdy'
       assert_includes(response.body, 'Howdy')
 
-      get :show, params: { id: 1, prerender: true, greeting: '👋' }
+      get :show, id: 1, prerender: true, greeting: '👋'
       assert_includes(response.body, '👋')
 
-      get :show, params: { id: 1, prerender: true }
+      get :show, id: 1, prerender: true
       assert_includes(response.body, 'Hello')
     end
   end
@@ -30,9 +30,9 @@ class PagesControllerTest < ActionController::TestCase
   WebpackerHelpers.when_webpacker_available do
     test 'it mounts components from the dev server' do
       WebpackerHelpers.with_dev_server do
-        get :show, params: { id: 1, prerender: true }
+        get :show, id: 1, prerender: true
         assert_match /Hello<!--.*--> from Webpacker/, response.body
-        get :show, params: { id: 1, prerender: true, greeting: 'Howdy' }
+        get :show, id: 1, prerender: true, greeting: 'Howdy'
         assert_match /Howdy<!--.*--> from Webpacker/, response.body
       end
     end

--- a/test/react/rails/pages_controller_test.rb
+++ b/test/react/rails/pages_controller_test.rb
@@ -13,16 +13,16 @@ class PagesControllerTest < ActionController::TestCase
 
   when_stateful_js_context_available do
     test 'it sets up and tears down a react context' do
-      get :show, id: 1, prerender: true
+      get :show, params: { id: 1, prerender: true }
       assert_includes(response.body, 'Hello')
 
-      get :show, id: 1, prerender: true, greeting: 'Howdy'
+      get :show, params: { id: 1, prerender: true, greeting: 'Howdy' }
       assert_includes(response.body, 'Howdy')
 
-      get :show, id: 1, prerender: true, greeting: '👋'
+      get :show, params: { id: 1, prerender: true, greeting: '👋' }
       assert_includes(response.body, '👋')
 
-      get :show, id: 1, prerender: true
+      get :show, params: { id: 1, prerender: true }
       assert_includes(response.body, 'Hello')
     end
   end
@@ -30,9 +30,9 @@ class PagesControllerTest < ActionController::TestCase
   WebpackerHelpers.when_webpacker_available do
     test 'it mounts components from the dev server' do
       WebpackerHelpers.with_dev_server do
-        get :show, id: 1, prerender: true
+        get :show, params: { id: 1, prerender: true }
         assert_match /Hello<!--.*--> from Webpacker/, response.body
-        get :show, id: 1, prerender: true, greeting: 'Howdy'
+        get :show, params: { id: 1, prerender: true, greeting: 'Howdy' }
         assert_match /Howdy<!--.*--> from Webpacker/, response.body
       end
     end

--- a/test/support/webpacker_helpers.rb
+++ b/test/support/webpacker_helpers.rb
@@ -21,10 +21,10 @@ module WebpackerHelpers
     return unless available?
     clear_webpacker_packs
     Dir.chdir("./test/#{DUMMY_LOCATION}") do
-      # capture_io do
+      capture_io do
         Rake::Task['webpacker:compile'].reenable
         Rake::Task['webpacker:compile'].invoke
-      # end
+      end
     end
     # Reload cached JSON manifest:
     manifest_refresh
@@ -40,122 +40,107 @@ module WebpackerHelpers
     FileUtils.rm_rf(PACKS_DIRECTORY)
   end
 
-  if MAJOR < 3
-    def manifest_refresh
-      Webpacker::Manifest.load
-    end
-  else
-    def manifest_refresh
-      Webpacker.manifest.refresh
-    end
-  end
-
-  if MAJOR < 3
-    def manifest_lookup name
-      Webpacker::Manifest.load(name)
-    end
-  else
-    def manifest_lookup _
-      Webpacker.manifest
-    end
-  end
-
-  if MAJOR < 3
-    def manifest_data
-      Webpacker::Manifest.instance.data
-    end
-  else
-    def manifest_data
-      Webpacker.manifest.refresh
-    end
-  end
-
   # Start a webpack-dev-server
   # Call the block
   # Make sure to clean up the server
   def with_dev_server
+
+    old_env = ENV['NODE_ENV']
+    ENV['NODE_ENV'] = 'development'
+
     # Start the server in a forked process:
     webpack_dev_server = Dir.chdir("test/#{DUMMY_LOCATION}") do
       spawn 'RAILS_ENV=development ./bin/webpack-dev-server '
     end
 
+    stop_time = Time.now + 30.seconds
     detected_dev_server = false
-
-    # Wait for it to start up, make sure it's there by connecting to it:
-    30.times do |i|
-      begin
-        # Make sure that the manifest has been updated:
-        manifest_lookup("./test/#{DUMMY_LOCATION}/public/packs/manifest.json")
-        example_asset_path = manifest_data.values.first
-        if example_asset_path.nil?
-          # Debug helper
-          # puts "Manifest is blank, all manifests:"
-          # Dir.glob("./test/#{DUMMY_LOCATION}/public/packs/*.json").each do |f|
-          #   puts f
-          #   puts File.read(f)
-          # end
-          next
-        end
-        # Make sure the dev server is up:
-        if MAJOR < 3
-          file = open('http://localhost:8080/packs/application.js')
-          if !example_asset_path.start_with?('http://localhost:8080') && ! file
-            raise "Manifest doesn't include absolute path to dev server"
-          end
-        else
-          # Webpacker proxies the dev server when Rails is running in Webpacker 3
-          #  so the manifest doens't have absolute paths anymore..
-          # Reload webpacker config.
-          old_env = ENV['NODE_ENV']
-          ENV['NODE_ENV'] = 'development'
-          Webpacker.instance.instance_variable_set(:@config, nil)
-          Webpacker.config
-          running = Webpacker.dev_server.running?
-          ENV['NODE_ENV'] = old_env
-          raise "Webpack Dev Server hasn't started yet" unless running
-        end
-
-        detected_dev_server = true
-        break
-      rescue StandardError => err
-        puts err.message
-      ensure
-        sleep 0.5
-        # debug counter
-        # puts i
-      end
+    loop do
+      detected_dev_server = dev_server_running?
+      break if detected_dev_server || Time.now > stop_time
+      sleep 0.5
     end
 
     # If we didn't hook up with a dev server after waiting, fail loudly.
-    unless detected_dev_server
-      raise 'Failed to start dev server'
-    end
+    raise 'Failed to start dev server' unless detected_dev_server
+    puts 'Detected dev server - Continuing'
 
     # Call the test block:
     yield
+
   ensure
     # Kill the server process
-    # puts "Killing webpack dev server"
-    check_cmd = 'lsof -i :8080 -S'
-    10.times do
-      # puts check_cmd
-      status = `#{check_cmd}`
-      # puts status
-      remaining_pid_match = status.match(/\n[a-z]+\s+(\d+)/)
-      if remaining_pid_match
-        remaining_pid = remaining_pid_match[1]
-        # puts "Remaining #{remaining_pid}"
-        kill_cmd = "kill -9 #{remaining_pid}"
-        # puts kill_cmd
-        `#{kill_cmd}`
-        sleep 0.5
-      else
-        break
-      end
-    end
+    puts "Killing webpack dev server"
+    kill_cmd = "kill -9 #{webpack_dev_server}"
 
+    puts kill_cmd
+    `#{kill_cmd}`
     # Remove the dev-server packs:
     WebpackerHelpers.clear_webpacker_packs
-    # puts "Killed."
+    ENV['NODE_ENV'] = old_env
+    puts "Killed."
+  end
+
+  if MAJOR < 3 # Old webpackers
+
+    def dev_server_running?
+      manifest_refresh
+      example_asset_path = manifest_data.values.first
+      begin
+        file = open('http://localhost:8080/packs/application.js')
+      rescue StandardError => e
+        file = nil
+      end
+      if !example_asset_path.start_with?('http://localhost:8080') && ! file
+        puts "Manifest doesn't include absolute path to dev server"
+        return false
+      end
+      true
+    end
+
+    def manifest_refresh
+      Webpacker::Manifest.load
+    end
+
+    def manifest_lookup name
+      Webpacker::Manifest.load(name)
+    end
+
+    def manifest_data
+      Webpacker::Manifest.instance.data
+    end
+
+  else # New webpackers
+
+    def dev_server_running?
+      Webpacker.instance.instance_variable_set(:@config, nil)
+      return false unless Webpacker.dev_server.running?
+
+      ds = Webpacker.dev_server
+      example_asset_path = manifest_data.values.first
+      begin
+        file = open("#{ds.protocol}://#{ds.host}:#{ds.port}#{example_asset_path}")
+      rescue StandardError => e
+        file = nil
+      end
+      if ! file
+        puts "Dev server is not serving assets yet"
+        return false
+      end
+      true
+    end
+
+    def manifest_refresh
+      Webpacker.manifest.refresh
+    end
+
+    def manifest_lookup _
+      Webpacker.manifest
+    end
+
+    def manifest_data
+      Webpacker.manifest.refresh
+    end
+
   end
 end


### PR DESCRIPTION
Hi again,

**Problem**
Noticed when 777 was merged to master, there was one timing problem test where in webpacker 3 
it's possible for it to say `Webpacker.dev_server.running? == true` before it was able to serve assets.

**Solution**
Check if the file is available in Webpacker 3 by opening it again, same as old method but using the dev_server methods. Also basically rewrote that loop while I was at it since we can just kill the PID and not need to do the `lsof` scan.

Also used the `param:` syntax for rails controller tests, it runs in Rails 3 and 5, and it also stops a deprecation warning so thats a freebie.

Also collected all the `MAJOR < 3` into one block, still not 100% sure about that patten but it seems to do a good job.