### PR TITLE
Prepare for 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # react-rails
 
+#### Breaking Changes
+
+#### New Features
+
+#### Deprecation
+
+#### Bug Fixes
+
+## 2.3.0
+
 #### New Features
 
 - Webpacker and Webpack 3 support #777

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,6 +10,7 @@ You can control what version of React.js (and JSXTransformer) is used by `react-
 | Gem      | React.js |
 |----------|----------|
 | master   | 15.6.2   |
+| 2.3.0    | 15.6.2   |
 | 2.2.1    | 15.4.2   |
 | 2.2.0    | 15.4.2   |
 | 2.1.0    | 15.4.2   |

--- a/lib/react/rails/version.rb
+++ b/lib/react/rails/version.rb
@@ -2,6 +2,6 @@ module React
   module Rails
     # If you change this, make sure to update VERSIONS.md
     # and republish the UJS by updating package.json and `bundle exec rake ujs:publish`
-    VERSION = '2.2.1'
+    VERSION = '2.3.0'
   end
 end


### PR DESCRIPTION
@rmosolgo Thanks for the readme additions for a release. Do we need to publish to NPM even if there is no JS change?

If so I'll get set up there and let you know the details for it, and if not then I will try a gem release.
Believe I already updated the Changelog with both PRs merged since 2.2.1 so that *should* be everything.

In this release:
- #777 Webpacker 3 support
- #789 React 15.6.2 update.

Planned next point release:
- Any bugfixes.
- #790 React 16 update.