### PR TITLE
Update javascript driver to headless chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 sudo: required
 dist: trusty
+addons:
+  chrome: stable
 cache:
   bundler: true
   yarn: true
@@ -32,9 +34,9 @@ matrix:
     - rvm: 2.1
       gemfile: gemfiles/rails_3.2.gemfile
     - rvm: 2.1
-      gemfile: rails_4.0.5.gemfile
+      gemfile: gemfiles/rails_4.0.5.gemfile
     - rvm: 2.1
-      gemfile: rails_4.0_with_therubyracer.gemfile
+      gemfile: gemfiles/rails_4.0_with_therubyracer.gemfile
     - rvm: 2.1
       gemfile: gemfiles/rails_4.2_sprockets_2.gemfile
     - rvm: 2.1
@@ -76,12 +78,6 @@ matrix:
     - rvm: jruby-9.1.9.0
 
 before_install:
-  - nvm install 7.8.0 && nvm use 7.8.0
-  - mkdir travis-phantomjs
-  - wget https://rmosolgo.github.io/assets/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
-  - phantomjs --version
   # Repo for Yarn
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Then restart your development server.
 
 This will:
 
-- add some `//= require`s to `application.js`  
+- add some `//= require`s to `application.js`
 - add a `components/` directory for React components
 - add `server_rendering.js` for [server-side rendering](#server-side-rendering)
 
@@ -108,7 +108,7 @@ window.Post = React.createClass({
 // or, equivalent:
 class Post extends React.Component {
   render() {
-    return <h1>{this.props.title}</h1>    
+    return <h1>{this.props.title}</h1>
   }
 }
 ```
@@ -483,6 +483,8 @@ You can also specify this option in `react_component`:
 ## Development
 
 - Run tests with `rake test` or `appraisal rake test`
+  - Integration tests run in Headless Chrome which is included in Chrome (59+ linux,OSX | 60+ Windows)
+  - ChromeDriver is included with `chromedriver-helper` gem so no need to manually install that 👍
 - Update React assets with `rake react:update`
 - Update the UJS with `rake ujs:update`
 - Releases:

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-minitest'
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'listen', '~> 3.0.0' # support Ruby 2.1
-  s.add_development_dependency 'poltergeist', '>= 0.3.3'
+  s.add_development_dependency 'chromedriver-helper'
+  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'test-unit', '~> 2.5'
   s.add_development_dependency 'rails', '>= 3.2'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,24 +29,30 @@ require 'rails/generators'
 require 'pathname'
 require 'minitest/mock'
 require 'capybara/rails'
-require 'capybara/poltergeist'
+require 'selenium/webdriver'
 Dummy::Application.load_tasks
 
 WebpackerHelpers.clear_webpacker_packs
 
 Capybara.app = Rails.application
 
-Capybara.register_driver :poltergeist_debug do |app|
-  poltergeist_options = {
-    # `page.driver.debug` will cause Poltergeist to open a browser window
-    inspector: true,
-    # hide warnings from React.js whitespace changes:
-    # and from React.createClass deprecation
-    js_errors: false
-  }
-  Capybara::Poltergeist::Driver.new(app, poltergeist_options)
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
-Capybara.javascript_driver = :poltergeist_debug
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) }
+  )
+
+  Capybara::Selenium::Driver.new(app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+  )
+end
+
+Capybara.javascript_driver = :headless_chrome
 Capybara.current_driver = Capybara.javascript_driver
 
 CACHE_PATH = Pathname.new File.expand_path("../#{DUMMY_LOCATION}/tmp/cache", __FILE__)


### PR DESCRIPTION
Been having trouble installing the correct combinations of yarn, node (7.x), and phantomJS (2.1.1) to make the tests run smoothly on other computers. Even though I have the same versions, Cliver has decided not to load Phantom on certain machines.

Decided it would make developing this gem easier for other new people if everything they needed was in the Gemspec which you can do with headless chrome. Which is also the most up to date option.
Based on: https://robots.thoughtbot.com/headless-feature-specs-with-chrome and https://docs.travis-ci.com/user/gui-and-headless-browsers/