### PR TITLE
CoffeeScript React component generator fix

### DIFF
--- a/lib/generators/templates/component.js.jsx.coffee
+++ b/lib/generators/templates/component.js.jsx.coffee
@@ -1,4 +1,4 @@
-<%= file_header %>class @<%= component_name %> extends React.Component
+<%= file_header %>class <%= component_name %> extends React.Component
 <% if attributes.size > 0 -%>
   @propTypes =
 <% attributes.each do |attribute| -%>


### PR DESCRIPTION
Class with @ didn't work with export in footer (there is no need to set classes in global scope if they will be exported anyway, imho)