### PR TITLE
Add match pattern for .js|x files in the example to prent loading other file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ This way, you can access top-level, default, or named exports.
 
 If `require` fails, `react-rails` falls back to the global namespace approach described in [Use with Asset Pipeline](#use-with-asset-pipeline).
 
-The `require.context` inserted into `packs/application.js` is used to load components. If you want to load components from a different directory, override it by calling `ReactRailsUJS.useContext`:
+The `require.context` ([docs](https://webpack.js.org/guides/dependency-management/#require-context)) inserted into `packs/application.js` is used to load components. If you want to load components from a different directory, override it by calling `ReactRailsUJS.useContext`:
 
 ```js
-var myCustomContext = require.context("custom_components", true)
+// Search the custom_components directory, its subdirectories (true) and match .js or .jsx files
+var myCustomContext = require.context("custom_components", true, /\.jsx?$/)
 var ReactRailsUJS = require("react_ujs")
 // use `custom_components/` for <%= react_component(...) %> calls
 ReactRailsUJS.useContext(myCustomContext)


### PR DESCRIPTION
## What's up?

Thanks for React Rails! It was a wonderful surprise to find out that I can get this to work with webpacker and still have server rendering. 

Im using pod style components. 

```
components/panel/index.jsx
components/panel/styles.scss
```

Was working with optimizing CSS and noticed that some SCSS files that are not required by components are also part of the bundle. I took quite a while to find the cause, after scanning through all the webpacker config (first suspicion) , I realized it's because of the generated `react-rails` integration. 

## The Issue
```jsx
const componentRequireContext = require.context("components", true);
```

- If no pattern is passed, Webpack will attempt to require every file
- The scss files get required by this line
- These will get included in the build even if you don't require them

## The Fix
`require.context` without a patten can cause this very hard to spot issue. It's probably prudent to make it only target js, jsx, coffee files etc.

The integration code was generated by the install step. Happy to try to change them in a PR but I thought I get some feedback from maintainers by leading off with a README change.