### PR TITLE
Use ES6 in ComponentGenerator for Webpacker

### DIFF
--- a/lib/generators/react/component_generator.rb
+++ b/lib/generators/react/component_generator.rb
@@ -90,11 +90,10 @@ module React
       }
 
       def create_component_file
-        template_extension = case
-        when options[:es6]
-          'es6.jsx'
-        when options[:coffee]
+        template_extension = if options[:coffee]
           'js.jsx.coffee'
+        elsif options[:es6] || webpacker?
+          'es6.jsx'
         else
           'js.jsx'
         end

--- a/test/generators/coffee_component_generator_test.rb
+++ b/test/generators/coffee_component_generator_test.rb
@@ -10,6 +10,13 @@ class CoffeeComponentGeneratorTest < Rails::Generators::TestCase
     def filename
       'app/javascript/components/GeneratedComponent.coffee'
     end
+
+    test 'that Webpacker defaults to ES6' do
+      run_generator  %w(GeneratedComponent name)
+
+      es6 = File.read(File.join(destination_root, 'app/javascript/components/GeneratedComponent.js'))
+      assert_match(%r{extends React.Component}, es6)
+    end
   else
     def filename
       'app/assets/javascripts/components/generated_component.js.jsx.coffee'


### PR DESCRIPTION
`webpacker:install:react` does not install createReactClass
Our generators should support Webpacker out of the box
Therefore we should use ES6 as the Webpacker default
https://reactjs.org/docs/react-without-es6.html

Fixes #820.