### PR TITLE
:bug: Fix bug that prevents loading assets with `webpacker-dev-server`

### DIFF
--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -42,6 +42,8 @@ module React
           asset_path = Webpacker.manifest.lookup(logical_path).to_s
           if Webpacker.dev_server.running?
             ds = Webpacker.dev_server
+            # Remove the protocol and host from the asset path. Sometimes webpacker includes this, sometimes it does not
+            asset_path.slice!("#{ds.protocol}://#{ds.host_with_port}")
             dev_server_asset = open("#{ds.protocol}://#{ds.host_with_port}#{asset_path}").read
             dev_server_asset.sub!(CLIENT_REQUIRE, '//\0')
             dev_server_asset


### PR DESCRIPTION
Issue #739

In certain circumstances `webpacker-dev-server` includes the full path
(protocol and host with port) in the paths generated for the
packs/manifest.json file. This addition removes the protocol, host, and
port from the asset path when present allowing assets to be correctly
loaded.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing!
