### PR TITLE
Fallback to Render if Hydrate is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 # react-rails
 
-#### Breaking Changes
-
-#### New Features
-
-#### Deprecation
-
+## 2.4.2
 #### Bug Fixes
+- ReactDOM.hydrate() may not be defined for everyone, it will now use hydrate if it is defined or fallback to render #832
 
 ## 2.4.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ It outputs an ironically webpacked couple of files into `lib/assets/react-source
 ##### Updating ReactRailsUJS
 - Update the UJS with `rake ujs:update`
 - (For Maintainers) To release a new NPM version:
-  - Update the version in `react_ujs/package.json`
+  - Update the version in `package.json`
   - Commit & push to master
   - `bundle exec rake ujs:publish` (runs `npm publish`)
 

--- a/lib/assets/javascripts/react_ujs.js
+++ b/lib/assets/javascripts/react_ujs.js
@@ -315,7 +315,11 @@ var ReactRailsUJS = {
         }
         throw new Error(message + ". Make sure your component is available to render.")
       } else {
-        ReactDOM.hydrate(React.createElement(constructor, props), node);
+        if (typeof ReactDOM.hydrate === "function") {
+          ReactDOM.hydrate(React.createElement(constructor, props), node);
+        } else {
+          ReactDOM.render(React.createElement(constructor, props), node);
+        }
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react_ujs",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Rails UJS for the react-rails gem",
   "main": "react_ujs/index.js",
   "files": [

--- a/react_ujs/dist/react_ujs.js
+++ b/react_ujs/dist/react_ujs.js
@@ -315,7 +315,11 @@ var ReactRailsUJS = {
         }
         throw new Error(message + ". Make sure your component is available to render.")
       } else {
-        ReactDOM.hydrate(React.createElement(constructor, props), node);
+        if (typeof ReactDOM.hydrate === "function") {
+          ReactDOM.hydrate(React.createElement(constructor, props), node);
+        } else {
+          ReactDOM.render(React.createElement(constructor, props), node);
+        }
       }
     }
   },

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -90,7 +90,11 @@ var ReactRailsUJS = {
         }
         throw new Error(message + ". Make sure your component is available to render.")
       } else {
-        ReactDOM.hydrate(React.createElement(constructor, props), node);
+        if (typeof ReactDOM.hydrate === "function") {
+          ReactDOM.hydrate(React.createElement(constructor, props), node);
+        } else {
+          ReactDOM.render(React.createElement(constructor, props), node);
+        }
       }
     }
   },


### PR DESCRIPTION
Fixes #832

### Summary
ReactDOM.hydrate() may not be defined for everyone, it will now use
hydrate if it is defined or fallback to render.

### Other Information

Will release a new package version followed by a gem version.