### PR TITLE
Modify an example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,20 +327,22 @@ Server renderers are stored in a pool and reused between requests. Threaded Rubi
 These are the default configurations:
 
 ```ruby
-# config/environments/application.rb
+# config/application.rb
 # These are the defaults if you don't specify any yourself
-MyApp::Application.configure do
-  # Settings for the pool of renderers:
-  config.react.server_renderer_pool_size  ||= 1  # ExecJS doesn't allow more than one on MRI
-  config.react.server_renderer_timeout    ||= 20 # seconds
-  config.react.server_renderer = React::ServerRendering::BundleRenderer
-  config.react.server_renderer_options = {
-    files: ["server_rendering.js"],       # files to load for prerendering
-    replay_console: true,                 # if true, console.* will be replayed client-side
-  }
-  # Changing files matching these dirs/exts will cause the server renderer to reload:
-  config.react.server_renderer_extensions = ["jsx", "js"]
-  config.react.server_renderer_directories = ["/app/assets/javascripts", "/app/javascript/"]
+module MyApp
+  class Application < Rails::Application
+    # Settings for the pool of renderers:
+    config.react.server_renderer_pool_size  ||= 1  # ExecJS doesn't allow more than one on MRI
+    config.react.server_renderer_timeout    ||= 20 # seconds
+    config.react.server_renderer = React::ServerRendering::BundleRenderer
+    config.react.server_renderer_options = {
+      files: ["server_rendering.js"],       # files to load for prerendering
+      replay_console: true,                 # if true, console.* will be replayed client-side
+    }
+    # Changing files matching these dirs/exts will cause the server renderer to reload:
+    config.react.server_renderer_extensions = ["jsx", "js"]
+    config.react.server_renderer_directories = ["/app/assets/javascripts", "/app/javascript/"]
+  end
 end
 ```
 


### PR DESCRIPTION
We probably don't have `config/environments/application.rb` by default. Do you mean `config/application.rb` or `config/environments/production.rb` ?

```
$ rails new myapp
$ ls config/environments/
development.rb	production.rb	test.rb
```