### PR TITLE
Ignore react library in code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,6 @@
-exclude_paths:
-- lib/assets/javascripts/JSXTransformer.js
-- lib/assets/react-source/
+version: '2'
+exclude_patterns:
+- lib/assets/
+- react-builds/
+- react_ujs/dist/
+- test/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+exclude_paths:
+- lib/assets/javascripts/JSXTransformer.js
+- lib/assets/react-source/


### PR DESCRIPTION
### Summary

code climate is enabled for this repo - so when viewing the project page, you see this:
![image](https://user-images.githubusercontent.com/12266/34074786-a32aa2c0-e31b-11e7-9d01-0e4615a62a5a.png)

and then this  claim it would take 8 months of dev time to fix the tech debt.
![image](https://user-images.githubusercontent.com/12266/34074787-bbf02ec4-e31b-11e7-9494-7d699f75f319.png)

Most of these are in the vendor/react asset files.

this adds a config file telling code climate to ignore vendor files
I think I identified these correctly, but I'm unsure.

If I've configured this right, it'll mean people are no longer greeted with warnings against using this gem

