### PR TITLE
add javascript_pack_tag helper check to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ This gives you:
 - [`ReactRailsUJS`](#ujs) setup in `app/javascript/packs/application.js`
 - `app/javascript/packs/server_rendering.js` for [server-side rendering](#server-side-rendering)
 
+Link the JavaScript pack in Rails view using `javascript_pack_tag` [helper](https://github.com/rails/webpacker#usage), for example:
+
+```
+<!-- application.html.erb -->
+<%= javascript_pack_tag 'application' %>
+```
+
 Generate your first component:
 
 ```


### PR DESCRIPTION
add javascript_pack_tag helper to readme.

### Summary

mention javascript_pack_tag helper in README.md,
so people check it by themselves instead 
creating a issue why their react component is not rendered
