### PR TITLE
Fix misleading comment in exec_js_renderer

### DIFF
--- a/lib/react/server_rendering/exec_js_renderer.rb
+++ b/lib/react/server_rendering/exec_js_renderer.rb
@@ -1,7 +1,7 @@
 module React
   module ServerRendering
     # A bare-bones renderer for React.js + Exec.js
-    # - Depends on global ReactDOMServer in the ExecJS context
+    # - Depends on global ReactRailsUJS in the ExecJS context
     # - No Rails dependency
     # - No browser concerns
     class ExecJSRenderer


### PR DESCRIPTION
### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

As of 41721c5374925384adc8679aa007789b598de969, `exec_js_renderer` now needs `ReactRailsUJS` to appear in the global context, not `ReactDOM`. This commit updates an outdated comment to avoid confusion.
