### PR TITLE
fix(README): correct react:install for rails < 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Add `webpacker` and `react-rails` to your gemfile and run the installers:
 
 ```
 $ bundle install
-$ rails webpacker:install
-$ rails webpacker:install:react
+$ rails webpacker:install       # OR (on rails version < 5.0) rake webpacker:install
+$ rails webpacker:install:react # OR (on rails version < 5.0) rake webpacker:install:react
 $ rails generate react:install
 ```
 


### PR DESCRIPTION
### Corrected installation commands for Rails version < 5.0

These commands will not work on rails < 5.0

```
$ rails webpacker:install
$ rails webpacker:install:react
```