### PR TITLE
Controller camelize_props: true

### DIFF
--- a/lib/react/rails/controller_renderer.rb
+++ b/lib/react/rails/controller_renderer.rb
@@ -28,7 +28,7 @@ module React
       # @return [String] HTML for `component_name` with `options[:props]`
       def call(component_name, options, &block)
         props = options.fetch(:props, {})
-        options = default_options.merge(options.slice(:data, :aria, :tag, :class, :id, :prerender))
+        options = default_options.merge(options.slice(:data, :aria, :tag, :class, :id, :prerender, :camelize_props))
         react_component(component_name, props, options, &block)
       end
 

--- a/test/dummy_sprockets/app/controllers/server_controller.rb
+++ b/test/dummy_sprockets/app/controllers/server_controller.rb
@@ -16,6 +16,14 @@ class ServerController < ApplicationController
     render(component_options.merge(prerender: false))
   end
 
+  def inline_component_with_camelize_props_prerender_true
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true
+  end
+
+  def inline_component_with_camelize_props_prerender_false
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true, prerender: false
+  end
+
   private
 
   def component_options

--- a/test/dummy_sprockets/config/routes.rb
+++ b/test/dummy_sprockets/config/routes.rb
@@ -6,6 +6,8 @@ Dummy::Application.routes.draw do
       get :console_example
       get :inline_component_prerender_true
       get :inline_component_prerender_false
+      get :inline_component_with_camelize_props_prerender_true
+      get :inline_component_with_camelize_props_prerender_false
     end
   end
 

--- a/test/dummy_webpacker1/app/controllers/server_controller.rb
+++ b/test/dummy_webpacker1/app/controllers/server_controller.rb
@@ -16,6 +16,14 @@ class ServerController < ApplicationController
     render(component_options.merge(prerender: false))
   end
 
+  def inline_component_with_camelize_props_prerender_true
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true
+  end
+
+  def inline_component_with_camelize_props_prerender_false
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true, prerender: false
+  end
+
   private
 
   def component_options

--- a/test/dummy_webpacker1/config/routes.rb
+++ b/test/dummy_webpacker1/config/routes.rb
@@ -5,6 +5,8 @@ Dummy::Application.routes.draw do
       get :console_example
       get :inline_component_prerender_true
       get :inline_component_prerender_false
+      get :inline_component_with_camelize_props_prerender_true
+      get :inline_component_with_camelize_props_prerender_false
     end
   end
 

--- a/test/dummy_webpacker2/app/controllers/server_controller.rb
+++ b/test/dummy_webpacker2/app/controllers/server_controller.rb
@@ -16,6 +16,14 @@ class ServerController < ApplicationController
     render(component_options.merge(prerender: false))
   end
 
+  def inline_component_with_camelize_props_prerender_true
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true
+  end
+
+  def inline_component_with_camelize_props_prerender_false
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true, prerender: false
+  end
+
   private
 
   def component_options

--- a/test/dummy_webpacker2/config/routes.rb
+++ b/test/dummy_webpacker2/config/routes.rb
@@ -5,6 +5,8 @@ Dummy::Application.routes.draw do
       get :console_example
       get :inline_component_prerender_true
       get :inline_component_prerender_false
+      get :inline_component_with_camelize_props_prerender_true
+      get :inline_component_with_camelize_props_prerender_false
     end
   end
 

--- a/test/dummy_webpacker3/app/controllers/server_controller.rb
+++ b/test/dummy_webpacker3/app/controllers/server_controller.rb
@@ -16,6 +16,14 @@ class ServerController < ApplicationController
     render(component_options.merge(prerender: false))
   end
 
+  def inline_component_with_camelize_props_prerender_true
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true
+  end
+
+  def inline_component_with_camelize_props_prerender_false
+    render component: 'TodoList', props: { test_camelize_props: true, todos: ['dummy'] }, camelize_props: true, prerender: false
+  end
+
   private
 
   def component_options

--- a/test/dummy_webpacker3/config/routes.rb
+++ b/test/dummy_webpacker3/config/routes.rb
@@ -5,6 +5,8 @@ Dummy::Application.routes.draw do
       get :console_example
       get :inline_component_prerender_true
       get :inline_component_prerender_false
+      get :inline_component_with_camelize_props_prerender_true
+      get :inline_component_with_camelize_props_prerender_false
     end
   end
 

--- a/test/server_rendered_html_test.rb
+++ b/test/server_rendered_html_test.rb
@@ -134,5 +134,17 @@ HEREDOC
       # make sure the tag closes immediately:
       assert_match(/<span.*data-react-class=\"TodoList\"[^<]*><\/span>/, rendered_html)
     end
+
+    test 'react inline component rendering with camelize_props (pre-rendered)' do
+      get '/server/inline_component_with_camelize_props_prerender_true'
+      rendered_html = response.body
+      assert_match(/data-react-props.*testCamelizeProps.*true/, rendered_html)
+    end
+
+    test 'react inline component rendering with camelize_props (not pre-rendered)' do
+      get '/server/inline_component_with_camelize_props_prerender_false'
+      rendered_html = response.body
+      assert_match(/data-react-props.*testCamelizeProps.*true/, rendered_html)
+    end
   end
 end


### PR DESCRIPTION
This allows the use of camelize props in controller actions.

```ruby
render component: 'Example', props: my_props, camelize_props: true
```
