### PR TITLE
Add class_path to allow generated components to reside in subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ $ rails g react:component HelloWorld greeting:string
 
 Your component is added to `app/javascript/components/` by default.
 
+You can also generate your component in a subdirectory:
+
+```
+$ rails g react:component my_subdirectory/HelloWorld greeting:string
+```
+
 [Render it in a Rails view](#view-helper):
 
 ```erb
@@ -135,7 +141,7 @@ $ bundle exec rails webpacker:install:typescript
 $ yarn add @types/react @types/react-dom
 ```
 
-Doing this will allow React-Rails to support the .tsx extension. 
+Doing this will allow React-Rails to support the .tsx extension.
 
 ## Use with Asset Pipeline
 

--- a/lib/generators/react/component_generator.rb
+++ b/lib/generators/react/component_generator.rb
@@ -112,7 +112,7 @@ module React
           target_dir = 'app/assets/javascripts/components'
         end
 
-        file_path = File.join(target_dir, "#{new_file_name}.#{extension}")
+        file_path = File.join(target_dir, class_path, "#{new_file_name}.#{extension}")
         template("component.#{template_extension}", file_path)
       end
 

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -10,9 +10,15 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     def filename
       'app/javascript/components/GeneratedComponent.js'
     end
+    def filename_with_subfolder
+      'app/javascript/components/generated_folder/GeneratedComponent.js'
+    end
   else
     def filename
       'app/assets/javascripts/components/generated_component.js.jsx'
+    end
+    def filename_with_subfolder
+      'app/assets/javascripts/components/generated_folder/generated_component.js.jsx'
     end
   end
 
@@ -20,6 +26,17 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     run_generator %w(GeneratedComponent)
 
     assert_file filename do |contents|
+      if WebpackerHelpers.available?
+        assert_match /^import React from "react"/, contents
+        assert_match /export default GeneratedComponent\n$/m, contents
+      end
+    end
+  end
+
+  test 'creates the component file in a subdirectory' do
+    puts WebpackerHelpers.available?
+    run_generator %w(generated_folder/GeneratedComponent)
+    assert_file filename_with_subfolder do |contents|
       if WebpackerHelpers.available?
         assert_match /^import React from "react"/, contents
         assert_match /export default GeneratedComponent\n$/m, contents


### PR DESCRIPTION
### Summary

Although the documentation references rendering components from sub-directories, the generator only allows generation of components in the `components/` directory. This PR adds `class_path` into the generated path, allowing use such as:

```
➜ rails g react:component frontend/my_component
Running via Spring preloader in process 45812
      create  app/javascript/components/frontend/MyComponent.js
```
