### PR TITLE
Test to fix issue #892 with chrome version change from stable to beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: required
 dist: trusty
 addons:
-  chrome: stable
+  chrome: beta
 cache:
   bundler: true
   yarn: true


### PR DESCRIPTION
### Summary

Trying to determine what causes 3 of 21 builds to fail, per Issue #892.  I already compared the previous working build's gem versions to the broken build and did not find any differences.  

The new version of Chrome (from version 64.0.3282.167-1 to 66.0.3359.139-1) might have affected the build, so I want to try to change the Chrome version.  It's installed in the travis.yml file, but you're only allowed to specify stable or beta as the version, not a number version of chrome.  

I'm creating this pull request because I want to test this change within a Travis build.