### PR TITLE
Improve the condition of webpacker major version

### DIFF
--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -77,7 +77,7 @@ module React
         def file_path path
           manifest.lookup_path(path)
         end
-      elsif MAJOR == 3
+      elsif MAJOR >= 3
         def file_path path
           ::Rails.root.join('public', manifest.lookup(path)[1..-1])
         end


### PR DESCRIPTION
### Summary

 I found server-side rendering failed in our environment Rails 5.2, webpacker 4.0.0.pre.pre.2, webpack 4.4.1. The error message is following.

```
Failure/Error: <%= react_component("SearchFilter", {}, {prerender: true}) %>

     ActionView::Template::Error:
       No such file or directory @ rb_sysopen - public/server_rendering-0c232d693da2fd422ba9.js
     # ./app/views/users/_filter.html.erb:2:in `_app_views_recipes__filter_html_erb___2340570384952592713_70205888111860'
     # ./app/views/users/index.html.erb:6:in `_app_views_users_index_html_erb___4199468956611823080_70205888379400'
     # ------------------
```

The path `public/server_rendering-0c232d693da2fd422ba9.js` is not proper because my webpacker.yaml is following. `public/packs/server_rendering-0c232d693da2fd422ba9.js` is correct.

```
default: &default
  source_path: app/javascript
  source_entry_path: packs
  public_output_path: packs
  cache_path: tmp/cache/webpacker
```

Since it depends on the version of webpacker, I mofidied `lib/react/server_rendering/webpacker_manifest_container.rb`.