### PR TITLE
Add frozen_string_literal pragma to ruby files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/lib/generators/react/component_generator.rb
+++ b/lib/generators/react/component_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Generators
     class ComponentGenerator < ::Rails::Generators::NamedBase

--- a/lib/generators/react/install_generator.rb
+++ b/lib/generators/react/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Generators
     class InstallGenerator < ::Rails::Generators::Base

--- a/lib/generators/templates/react_server_rendering.rb
+++ b/lib/generators/templates/react_server_rendering.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # To render React components in production, precompile the server rendering manifest:
 Rails.application.config.assets.precompile += ['server_rendering.js']

--- a/lib/react-rails.rb
+++ b/lib/react-rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'react'
 require 'react/jsx'
 require 'react/rails'

--- a/lib/react.rb
+++ b/lib/react.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   # Recursively camelize `props`, returning a new Hash
   # @param props [Object] If it's a Hash or Array, it will be recursed. Otherwise it will be returned.

--- a/lib/react/jsx.rb
+++ b/lib/react/jsx.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'execjs'
 require 'react/jsx/processor'
 require 'react/jsx/template'

--- a/lib/react/jsx/babel_transformer.rb
+++ b/lib/react/jsx/babel_transformer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'babel/transpiler'
 module React
   module JSX

--- a/lib/react/jsx/jsx_transformer.rb
+++ b/lib/react/jsx/jsx_transformer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module JSX
     # A {React::JSX}-compliant transformer which uses the deprecated `JSXTransformer.js` to transform JSX.

--- a/lib/react/jsx/processor.rb
+++ b/lib/react/jsx/processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module JSX
     # A Sprockets 3+-compliant processor

--- a/lib/react/jsx/sprockets_strategy.rb
+++ b/lib/react/jsx/sprockets_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module JSX
     # Depending on the Sprockets version,

--- a/lib/react/jsx/template.rb
+++ b/lib/react/jsx/template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tilt'
 
 module React

--- a/lib/react/rails.rb
+++ b/lib/react/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'react/rails/asset_variant'
 require 'react/rails/railtie'
 require 'react/rails/controller_lifecycle'

--- a/lib/react/rails/asset_variant.rb
+++ b/lib/react/rails/asset_variant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Rails
     # This class accepts some options for which build you want, then exposes where you can find

--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Rails
     # This is the default view helper implementation.

--- a/lib/react/rails/controller_lifecycle.rb
+++ b/lib/react/rails/controller_lifecycle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Rails
     # This module is included into ActionController so that

--- a/lib/react/rails/controller_renderer.rb
+++ b/lib/react/rails/controller_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Rails
     # A renderer class suitable for `ActionController::Renderers`.

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails'
 
 module React

--- a/lib/react/rails/version.rb
+++ b/lib/react/rails/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Rails
     # If you change this, make sure to update VERSIONS.md

--- a/lib/react/rails/view_helper.rb
+++ b/lib/react/rails/view_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module Rails
     module ViewHelper

--- a/lib/react/server_rendering.rb
+++ b/lib/react/server_rendering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'connection_pool'
 require 'react/server_rendering/exec_js_renderer'
 require 'react/server_rendering/bundle_renderer'

--- a/lib/react/server_rendering/bundle_renderer.rb
+++ b/lib/react/server_rendering/bundle_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'react/server_rendering/environment_container'
 require 'react/server_rendering/manifest_container'
 require 'react/server_rendering/webpacker_manifest_container'

--- a/lib/react/server_rendering/environment_container.rb
+++ b/lib/react/server_rendering/environment_container.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module ServerRendering
     # Return asset contents by getting them from a Sprockets::Environment instance.

--- a/lib/react/server_rendering/exec_js_renderer.rb
+++ b/lib/react/server_rendering/exec_js_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module ServerRendering
     # A bare-bones renderer for React.js + Exec.js

--- a/lib/react/server_rendering/manifest_container.rb
+++ b/lib/react/server_rendering/manifest_container.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module ServerRendering
     # Get asset content by reading the compiled file from disk using a Sprockets::Manifest.

--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open-uri'
 
 module React

--- a/lib/react/server_rendering/yaml_manifest_container.rb
+++ b/lib/react/server_rendering/yaml_manifest_container.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module React
   module ServerRendering
     # Get asset content by reading the compiled file from disk using the generated manifest.yml file

--- a/test/dummy_sprockets/Rakefile
+++ b/test/dummy_sprockets/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/test/dummy_sprockets/app/controllers/application_controller.rb
+++ b/test/dummy_sprockets/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/test/dummy_sprockets/app/controllers/pack_components_controller.rb
+++ b/test/dummy_sprockets/app/controllers/pack_components_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PackComponentsController < ApplicationController
   # make sure Sprockets application.js isn't loaded:
   layout false

--- a/test/dummy_sprockets/app/controllers/pages_controller.rb
+++ b/test/dummy_sprockets/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
   if WebpackerHelpers.available? || SprocketsHelpers.available?
     per_request_react_rails_prerenderer

--- a/test/dummy_sprockets/app/controllers/server_controller.rb
+++ b/test/dummy_sprockets/app/controllers/server_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerController < ApplicationController
   def show
     @component_name = params[:component_name] || "TodoList"

--- a/test/dummy_sprockets/app/helpers/application_helper.rb
+++ b/test/dummy_sprockets/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/dummy_sprockets/config/application.rb
+++ b/test/dummy_sprockets/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:

--- a/test/dummy_sprockets/config/boot.rb
+++ b/test/dummy_sprockets/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/test/dummy_sprockets/config/environment.rb
+++ b/test/dummy_sprockets/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy_sprockets/config/environments/development.rb
+++ b/test/dummy_sprockets/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_sprockets/config/environments/production.rb
+++ b/test/dummy_sprockets/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_sprockets/config/environments/test.rb
+++ b/test/dummy_sprockets/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_sprockets/config/initializers/backtrace_silencers.rb
+++ b/test/dummy_sprockets/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy_sprockets/config/initializers/filter_parameter_logging.rb
+++ b/test/dummy_sprockets/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/dummy_sprockets/config/initializers/inflections.rb
+++ b/test/dummy_sprockets/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/dummy_sprockets/config/initializers/mime_types.rb
+++ b/test/dummy_sprockets/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy_sprockets/config/initializers/react.rb
+++ b/test/dummy_sprockets/config/initializers/react.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Override setting set in application.rb
 class CustomComponentMount < React::Rails::ComponentMount
 end

--- a/test/dummy_sprockets/config/initializers/secret_token.rb
+++ b/test/dummy_sprockets/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.

--- a/test/dummy_sprockets/config/initializers/session_store.rb
+++ b/test/dummy_sprockets/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'

--- a/test/dummy_sprockets/config/initializers/wrap_parameters.rb
+++ b/test/dummy_sprockets/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/dummy_sprockets/config/routes.rb
+++ b/test/dummy_sprockets/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.routes.draw do
   get 'no-turbolinks', to: 'pages#no_turbolinks'
   resources :pages, only: [:show]

--- a/test/dummy_webpacker1/Rakefile
+++ b/test/dummy_webpacker1/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/test/dummy_webpacker1/app/controllers/application_controller.rb
+++ b/test/dummy_webpacker1/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/test/dummy_webpacker1/app/controllers/pack_components_controller.rb
+++ b/test/dummy_webpacker1/app/controllers/pack_components_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PackComponentsController < ApplicationController
   # make sure Sprockets application.js isn't loaded:
   layout false

--- a/test/dummy_webpacker1/app/controllers/pages_controller.rb
+++ b/test/dummy_webpacker1/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
   if WebpackerHelpers.available? || SprocketsHelpers.available?
     per_request_react_rails_prerenderer

--- a/test/dummy_webpacker1/app/controllers/server_controller.rb
+++ b/test/dummy_webpacker1/app/controllers/server_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerController < ApplicationController
   def show
     @component_name = params[:component_name] || "TodoList"

--- a/test/dummy_webpacker1/app/helpers/application_helper.rb
+++ b/test/dummy_webpacker1/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/dummy_webpacker1/config/application.rb
+++ b/test/dummy_webpacker1/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:

--- a/test/dummy_webpacker1/config/boot.rb
+++ b/test/dummy_webpacker1/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/test/dummy_webpacker1/config/environment.rb
+++ b/test/dummy_webpacker1/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy_webpacker1/config/environments/development.rb
+++ b/test/dummy_webpacker1/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker1/config/environments/production.rb
+++ b/test/dummy_webpacker1/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker1/config/environments/test.rb
+++ b/test/dummy_webpacker1/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker1/config/initializers/backtrace_silencers.rb
+++ b/test/dummy_webpacker1/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy_webpacker1/config/initializers/filter_parameter_logging.rb
+++ b/test/dummy_webpacker1/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/dummy_webpacker1/config/initializers/inflections.rb
+++ b/test/dummy_webpacker1/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/dummy_webpacker1/config/initializers/mime_types.rb
+++ b/test/dummy_webpacker1/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy_webpacker1/config/initializers/react.rb
+++ b/test/dummy_webpacker1/config/initializers/react.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Override setting set in application.rb
 class CustomComponentMount < React::Rails::ComponentMount
 end

--- a/test/dummy_webpacker1/config/initializers/secret_token.rb
+++ b/test/dummy_webpacker1/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.

--- a/test/dummy_webpacker1/config/initializers/session_store.rb
+++ b/test/dummy_webpacker1/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'

--- a/test/dummy_webpacker1/config/initializers/wrap_parameters.rb
+++ b/test/dummy_webpacker1/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/dummy_webpacker1/config/routes.rb
+++ b/test/dummy_webpacker1/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.routes.draw do
   resources :pages, only: [:show]
   resources :server, only: [:show] do

--- a/test/dummy_webpacker2/Rakefile
+++ b/test/dummy_webpacker2/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/test/dummy_webpacker2/app/controllers/application_controller.rb
+++ b/test/dummy_webpacker2/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/test/dummy_webpacker2/app/controllers/pack_components_controller.rb
+++ b/test/dummy_webpacker2/app/controllers/pack_components_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PackComponentsController < ApplicationController
   # make sure Sprockets application.js isn't loaded:
   layout false

--- a/test/dummy_webpacker2/app/controllers/pages_controller.rb
+++ b/test/dummy_webpacker2/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
   if WebpackerHelpers.available? || SprocketsHelpers.available?
     per_request_react_rails_prerenderer

--- a/test/dummy_webpacker2/app/controllers/server_controller.rb
+++ b/test/dummy_webpacker2/app/controllers/server_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerController < ApplicationController
   def show
     @component_name = params[:component_name] || "TodoList"

--- a/test/dummy_webpacker2/app/helpers/application_helper.rb
+++ b/test/dummy_webpacker2/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/dummy_webpacker2/config/application.rb
+++ b/test/dummy_webpacker2/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:

--- a/test/dummy_webpacker2/config/boot.rb
+++ b/test/dummy_webpacker2/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/test/dummy_webpacker2/config/environment.rb
+++ b/test/dummy_webpacker2/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy_webpacker2/config/environments/development.rb
+++ b/test/dummy_webpacker2/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker2/config/environments/production.rb
+++ b/test/dummy_webpacker2/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker2/config/environments/test.rb
+++ b/test/dummy_webpacker2/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker2/config/initializers/backtrace_silencers.rb
+++ b/test/dummy_webpacker2/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy_webpacker2/config/initializers/filter_parameter_logging.rb
+++ b/test/dummy_webpacker2/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/dummy_webpacker2/config/initializers/inflections.rb
+++ b/test/dummy_webpacker2/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/dummy_webpacker2/config/initializers/mime_types.rb
+++ b/test/dummy_webpacker2/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy_webpacker2/config/initializers/react.rb
+++ b/test/dummy_webpacker2/config/initializers/react.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Override setting set in application.rb
 class CustomComponentMount < React::Rails::ComponentMount
 end

--- a/test/dummy_webpacker2/config/initializers/secret_token.rb
+++ b/test/dummy_webpacker2/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.

--- a/test/dummy_webpacker2/config/initializers/session_store.rb
+++ b/test/dummy_webpacker2/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'

--- a/test/dummy_webpacker2/config/initializers/wrap_parameters.rb
+++ b/test/dummy_webpacker2/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/dummy_webpacker2/config/routes.rb
+++ b/test/dummy_webpacker2/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.routes.draw do
   resources :pages, only: [:show]
   resources :server, only: [:show] do

--- a/test/dummy_webpacker3/Rakefile
+++ b/test/dummy_webpacker3/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/test/dummy_webpacker3/app/controllers/application_controller.rb
+++ b/test/dummy_webpacker3/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/test/dummy_webpacker3/app/controllers/pack_components_controller.rb
+++ b/test/dummy_webpacker3/app/controllers/pack_components_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PackComponentsController < ApplicationController
   # make sure Sprockets application.js isn't loaded:
   layout false

--- a/test/dummy_webpacker3/app/controllers/pages_controller.rb
+++ b/test/dummy_webpacker3/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
   if WebpackerHelpers.available? || SprocketsHelpers.available?
     per_request_react_rails_prerenderer

--- a/test/dummy_webpacker3/app/controllers/server_controller.rb
+++ b/test/dummy_webpacker3/app/controllers/server_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerController < ApplicationController
   def show
     @component_name = params[:component_name] || "TodoList"

--- a/test/dummy_webpacker3/app/helpers/application_helper.rb
+++ b/test/dummy_webpacker3/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/test/dummy_webpacker3/config/application.rb
+++ b/test/dummy_webpacker3/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:

--- a/test/dummy_webpacker3/config/boot.rb
+++ b/test/dummy_webpacker3/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/test/dummy_webpacker3/config/environment.rb
+++ b/test/dummy_webpacker3/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy_webpacker3/config/environments/development.rb
+++ b/test/dummy_webpacker3/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker3/config/environments/production.rb
+++ b/test/dummy_webpacker3/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker3/config/environments/test.rb
+++ b/test/dummy_webpacker3/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/test/dummy_webpacker3/config/initializers/backtrace_silencers.rb
+++ b/test/dummy_webpacker3/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy_webpacker3/config/initializers/filter_parameter_logging.rb
+++ b/test/dummy_webpacker3/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/test/dummy_webpacker3/config/initializers/inflections.rb
+++ b/test/dummy_webpacker3/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/test/dummy_webpacker3/config/initializers/mime_types.rb
+++ b/test/dummy_webpacker3/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy_webpacker3/config/initializers/react.rb
+++ b/test/dummy_webpacker3/config/initializers/react.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Override setting set in application.rb
 class CustomComponentMount < React::Rails::ComponentMount
 end

--- a/test/dummy_webpacker3/config/initializers/secret_token.rb
+++ b/test/dummy_webpacker3/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.

--- a/test/dummy_webpacker3/config/initializers/session_store.rb
+++ b/test/dummy_webpacker3/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'

--- a/test/dummy_webpacker3/config/initializers/wrap_parameters.rb
+++ b/test/dummy_webpacker3/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/dummy_webpacker3/config/routes.rb
+++ b/test/dummy_webpacker3/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dummy::Application.routes.draw do
   resources :pages, only: [:show]
   resources :server, only: [:show] do

--- a/test/generators/coffee_component_generator_test.rb
+++ b/test/generators/coffee_component_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'generators/react/component_generator'
 

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'generators/react/component_generator'
 

--- a/test/generators/es6_component_generator_test.rb
+++ b/test/generators/es6_component_generator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require 'test_helper'
 require 'generators/react/component_generator'

--- a/test/generators/install_generator_sprockets_test.rb
+++ b/test/generators/install_generator_sprockets_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'generators/react/install_generator'
 

--- a/test/generators/install_generator_webpacker_test.rb
+++ b/test/generators/install_generator_webpacker_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'generators/react/install_generator'
 

--- a/test/react/jsx/jsx_prepocessor_test.rb
+++ b/test/react/jsx/jsx_prepocessor_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 SprocketsHelpers.when_available do

--- a/test/react/jsx/jsx_transformer_test.rb
+++ b/test/react/jsx/jsx_transformer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 SprocketsHelpers.when_available do

--- a/test/react/jsx_test.rb
+++ b/test/react/jsx_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Sprockets is inserting a newline after the docblock for some reason...

--- a/test/react/rails/asset_variant_test.rb
+++ b/test/react/rails/asset_variant_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AssetVariantTest < ActiveSupport::TestCase

--- a/test/react/rails/component_mount_test.rb
+++ b/test/react/rails/component_mount_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 SprocketsHelpers.when_available do

--- a/test/react/rails/controller_lifecycle_test.rb
+++ b/test/react/rails/controller_lifecycle_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # This helper implementation just counts the number of

--- a/test/react/rails/pages_controller_test.rb
+++ b/test/react/rails/pages_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PagesControllerTest < ActionController::TestCase

--- a/test/react/rails/railtie_test.rb
+++ b/test/react/rails/railtie_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RailtieTest < ActionDispatch::IntegrationTest

--- a/test/react/rails/react_rails_ujs_test.rb
+++ b/test/react/rails/react_rails_ujs_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 SprocketsHelpers.when_available do

--- a/test/react/rails/view_helper_test.rb
+++ b/test/react/rails/view_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Provide direct access to the view helper methods

--- a/test/react/rails/webpacker_test.rb
+++ b/test/react/rails/webpacker_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 WebpackerHelpers.when_webpacker_available do

--- a/test/react/server_rendering/bundle_renderer_test.rb
+++ b/test/react/server_rendering/bundle_renderer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 if SprocketsHelpers.available? || WebpackerHelpers.available?

--- a/test/react/server_rendering/console_replay_test.rb
+++ b/test/react/server_rendering/console_replay_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 if WebpackerHelpers.available? || SprocketsHelpers.available?

--- a/test/react/server_rendering/exec_js_renderer_test.rb
+++ b/test/react/server_rendering/exec_js_renderer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 DUMMY_IMPLEMENTATION = "

--- a/test/react/server_rendering/manifest_container_test.rb
+++ b/test/react/server_rendering/manifest_container_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # sprockets-rails < 2.2.2 does not support

--- a/test/react/server_rendering/webpacker_manifest_container_test.rb
+++ b/test/react/server_rendering/webpacker_manifest_container_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'open-uri'
 

--- a/test/react/server_rendering/yaml_manifest_container_test.rb
+++ b/test/react/server_rendering/yaml_manifest_container_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 if Rails::VERSION::MAJOR == 3

--- a/test/react/server_rendering_test.rb
+++ b/test/react/server_rendering_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NullRenderer

--- a/test/react_asset_test.rb
+++ b/test/react_asset_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 SprocketsHelpers.when_available do

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ReactTest < ActiveSupport::TestCase

--- a/test/server_rendered_html_test.rb
+++ b/test/server_rendered_html_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'fileutils'
 

--- a/test/support/sprockets_helpers.rb
+++ b/test/support/sprockets_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SprocketsHelpers
   module_function
   def available?

--- a/test/support/webpacker_helpers.rb
+++ b/test/support/webpacker_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebpackerHelpers
   PACKS_DIRECTORY =  File.expand_path("../../#{DUMMY_LOCATION}/public/packs", __FILE__)
   begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_PLATFORM != 'java'
   require 'simplecov'
   SimpleCov.start


### PR DESCRIPTION
### Summary

Add `# frozen_string_literal: true` pragma to ruby files. According to this blog post: https://www.mikeperham.com/2018/02/28/ruby-optimization-with-one-magic-comment/