### PR TITLE
Added documentation for babel transform plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ Components must be accessible from the top level, but they may be namespaced, fo
 
 `react-rails` provides two transformers, `React::JSX::BabelTransformer` (which uses [ruby-babel-transpiler](https://github.com/babel/ruby-babel-transpiler)) and `React::JSX::JSXTransformer` (which uses the deprecated `JSXTransformer.js`).
 
+#### Transform Plugin Options
+
+To supply additional transform plugins to your JSX Transformer, assign them to `config.react.jsx_transform_options`
+
+`react-rails` uses the Babel version of the `babel-source` gem.
+
+For example, to use `babel-plugin-transform-class-properties` :
+
+    config.react.jsx_transform_options = {
+      optional: ['es7.classProperties']
+    }
+
 ### React.js versions
 
 `//= require react` brings `React` into your project.


### PR DESCRIPTION
### Summary

Added subheading `#### Transform Plugin Options` to  `### Custom JSX Transformer` to outline how to add custom babel transform plugins to the asset pipeline

### Other Information

First time users who don't understand the structure of the gem have no way of knowing how to add transform plugins, or what version of babel react-rails is using to use the correct syntax.

Related to https://github.com/reactjs/react-rails/issues/401#issuecomment-411682998
