### PR TITLE
Support camelizing ActionController::Parameters

### DIFF
--- a/lib/react.rb
+++ b/lib/react.rb
@@ -13,7 +13,11 @@ module React
     when Array
       props.map { |item| camelize_props(item) }
     else
-      props
+      if defined?(ActionController::Parameters) && props.is_a?(ActionController::Parameters)
+        camelize_props(props.to_h)
+      else
+        props
+      end
     end
   end
 end

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -28,4 +28,23 @@ class ReactTest < ActiveSupport::TestCase
 
     assert_equal expected_props, React.camelize_props(raw_props)
   end
+
+  def test_it_camelizes_params
+    raw_params = ActionController::Parameters.new({
+      foo_bar_baz: 'foo bar baz',
+      nested_keys: {
+        qux_etc: 'bish bash bosh'
+      }
+    })
+    permitted_params = raw_params.permit(:foo_bar_baz, nested_keys: :qux_etc)
+
+    expected_params = {
+      'fooBarBaz' => 'foo bar baz',
+      'nestedKeys' => {
+        'quxEtc' => 'bish bash bosh'
+      }
+    }
+
+    assert_equal expected_params, React.camelize_props(permitted_params)
+  end
 end


### PR DESCRIPTION
### Summary

Adds support for React.camelize_props to camelize an instance of
ActionController::Parameters hash, so that permitted, strong parameters
in a Rails controller can be passed to a React component.

### Other Information

Resolves #931
