### PR TITLE
Use .keep instead of .gitkeep to match Rails itself.

### DIFF
--- a/lib/generators/react/install_generator.rb
+++ b/lib/generators/react/install_generator.rb
@@ -25,7 +25,7 @@ module React
         end
         empty_directory File.join(components_dir, 'components')
         unless options[:skip_git]
-          create_file File.join(components_dir, 'components/.gitkeep')
+          create_file File.join(components_dir, 'components/.keep')
         end
       end
 


### PR DESCRIPTION
Also, if someone is not using git, a .gitkeep feels odd, where a .keep seems fine.