### PR TITLE
Add semi-colons to generated JavaScript

### DIFF
--- a/lib/generators/react/install_generator.rb
+++ b/lib/generators/react/install_generator.rb
@@ -96,9 +96,9 @@ module React
 
       WEBPACKER_SETUP_UJS = <<-JS
 // Support component names relative to this directory:
-var componentRequireContext = require.context("components", true)
-var ReactRailsUJS = require("react_ujs")
-ReactRailsUJS.useContext(componentRequireContext)
+var componentRequireContext = require.context("components", true);
+var ReactRailsUJS = require("react_ujs");
+ReactRailsUJS.useContext(componentRequireContext);
 JS
 
       def setup_react_webpacker

--- a/lib/generators/templates/server_rendering_pack.js
+++ b/lib/generators/templates/server_rendering_pack.js
@@ -1,5 +1,5 @@
 // By default, this pack is loaded for server-side rendering.
 // It must expose react_ujs as `ReactRailsUJS` and prepare a require context.
-var componentRequireContext = require.context("components", true)
-var ReactRailsUJS = require("react_ujs")
-ReactRailsUJS.useContext(componentRequireContext)
+var componentRequireContext = require.context("components", true);
+var ReactRailsUJS = require("react_ujs");
+ReactRailsUJS.useContext(componentRequireContext);

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -16,19 +16,18 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'bundler', '>= 1.2.2'
-  s.add_development_dependency 'capybara'
-  s.add_development_dependency 'chromedriver-helper'
   s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'es5-shim-rails', '>= 2.0.5'
-  s.add_development_dependency 'guard-minitest'
   s.add_development_dependency 'guard'
+  s.add_development_dependency 'guard-minitest'
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'listen', '~> 3.0.0' # support Ruby 2.1
-  s.add_development_dependency 'rails', '>= 3.2'
+  s.add_development_dependency 'chromedriver-helper'
+  s.add_development_dependency 'capybara'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'test-unit', '~> 2.5'
-  s.add_development_dependency 'turbolinks'
+  s.add_development_dependency 'rails', '>= 3.2'
 
   s.add_dependency 'connection_pool'
   s.add_dependency 'execjs'

--- a/react-rails.gemspec
+++ b/react-rails.gemspec
@@ -16,18 +16,19 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'bundler', '>= 1.2.2'
+  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'chromedriver-helper'
   s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'es5-shim-rails', '>= 2.0.5'
-  s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-minitest'
+  s.add_development_dependency 'guard'
   s.add_development_dependency 'jbuilder'
   s.add_development_dependency 'listen', '~> 3.0.0' # support Ruby 2.1
-  s.add_development_dependency 'chromedriver-helper'
-  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'rails', '>= 3.2'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'test-unit', '~> 2.5'
-  s.add_development_dependency 'rails', '>= 3.2'
+  s.add_development_dependency 'turbolinks'
 
   s.add_dependency 'connection_pool'
   s.add_dependency 'execjs'

--- a/test/dummy_webpacker1/app/javascript/packs/server_rendering.js
+++ b/test/dummy_webpacker1/app/javascript/packs/server_rendering.js
@@ -1,5 +1,5 @@
 // By default, this pack is loaded for server-side rendering.
 // It must expose react_ujs as `ReactRailsUJS` and prepare a require context.
-var componentRequireContext = require.context("components", true)
-var ReactRailsUJS = require("../../../../../react_ujs/index")
-ReactRailsUJS.useContext(componentRequireContext)
+var componentRequireContext = require.context("components", true);
+var ReactRailsUJS = require("../../../../../react_ujs/index");
+ReactRailsUJS.useContext(componentRequireContext);

--- a/test/dummy_webpacker2/app/javascript/packs/server_rendering.js
+++ b/test/dummy_webpacker2/app/javascript/packs/server_rendering.js
@@ -1,5 +1,5 @@
 // By default, this pack is loaded for server-side rendering.
 // It must expose react_ujs as `ReactRailsUJS` and prepare a require context.
-var componentRequireContext = require.context("components", true)
-var ReactRailsUJS = require("react_ujs")
-ReactRailsUJS.useContext(componentRequireContext)
+var componentRequireContext = require.context("components", true);
+var ReactRailsUJS = require("react_ujs");
+ReactRailsUJS.useContext(componentRequireContext);

--- a/test/dummy_webpacker3/app/javascript/packs/server_rendering.js
+++ b/test/dummy_webpacker3/app/javascript/packs/server_rendering.js
@@ -1,5 +1,5 @@
 // By default, this pack is loaded for server-side rendering.
 // It must expose react_ujs as `ReactRailsUJS` and prepare a require context.
-var componentRequireContext = require.context("components", true)
-var ReactRailsUJS = require("react_ujs")
-ReactRailsUJS.useContext(componentRequireContext)
+var componentRequireContext = require.context("components", true);
+var ReactRailsUJS = require("react_ujs");
+ReactRailsUJS.useContext(componentRequireContext);

--- a/test/generators/install_generator_webpacker_test.rb
+++ b/test/generators/install_generator_webpacker_test.rb
@@ -8,9 +8,9 @@ WebpackerHelpers.when_webpacker_available do
     setup :prepare_destination
 
     EXPECTED_SETUP = %|// Support component names relative to this directory:
-var componentRequireContext = require.context("components", true)
-var ReactRailsUJS = require("react_ujs")
-ReactRailsUJS.useContext(componentRequireContext)
+var componentRequireContext = require.context("components", true);
+var ReactRailsUJS = require("react_ujs");
+ReactRailsUJS.useContext(componentRequireContext);
 |
 
     DEFAULT_SERVER_RENDERING_PACK_PATH = 'app/javascript/packs/server_rendering.js'
@@ -32,9 +32,9 @@ ReactRailsUJS.useContext(componentRequireContext)
     test 'creates server_rendering.js with default requires' do
       run_generator
       assert_file DEFAULT_SERVER_RENDERING_PACK_PATH do |contents|
-        assert_includes contents, "var componentRequireContext = require.context(\"components\", true)\n"
-        assert_includes contents, "var ReactRailsUJS = require(\"react_ujs\")\n"
-        assert_includes contents, "ReactRailsUJS.useContext(componentRequireContext)\n"
+        assert_includes contents, "var componentRequireContext = require.context(\"components\", true);\n"
+        assert_includes contents, "var ReactRailsUJS = require(\"react_ujs\");\n"
+        assert_includes contents, "ReactRailsUJS.useContext(componentRequireContext);\n"
       end
     end
 


### PR DESCRIPTION
### Summary

Add semi-colons to generated JavaScript which is created when using the generator.

Seems like good practice and I always end up doing this myself after running the generator anyway for the sake of cleanliness. May as well fix it at the source, eh?

### Other Information

N/A