### PR TITLE
Camelize all props that can be converted to JSON

### DIFF
--- a/lib/react.rb
+++ b/lib/react.rb
@@ -3,21 +3,19 @@ module React
   # @param props [Object] If it's a Hash or Array, it will be recursed. Otherwise it will be returned.
   # @return [Hash] a new hash whose keys are camelized strings
   def self.camelize_props(props)
-    case props
+    props_as_json = props.as_json
+
+    case props_as_json
     when Hash
-      props.each_with_object({}) do |(key, value), new_props|
+      props_as_json.each_with_object({}) do |(key, value), new_props|
         new_key = key.to_s.camelize(:lower)
         new_value = camelize_props(value)
         new_props[new_key] = new_value
       end
     when Array
-      props.map { |item| camelize_props(item) }
+      props_as_json.map { |item| camelize_props(item) }
     else
-      if defined?(ActionController::Parameters) && props.is_a?(ActionController::Parameters)
-        camelize_props(props.to_h)
-      else
-        props
-      end
+      props_as_json
     end
   end
 end

--- a/test/react_test.rb
+++ b/test/react_test.rb
@@ -23,7 +23,7 @@ class ReactTest < ActiveSupport::TestCase
           [{ 'nestedArray' => {} }]
         ]
       },
-      'alreadyCamelized' => :ok
+      'alreadyCamelized' => 'ok'
     }
 
     assert_equal expected_props, React.camelize_props(raw_props)
@@ -46,5 +46,35 @@ class ReactTest < ActiveSupport::TestCase
     }
 
     assert_equal expected_params, React.camelize_props(permitted_params)
+  end
+
+  def test_it_camelizes_json_serializable_objects
+    my_json_serializer = Class.new do
+      def initialize(data)
+        @data = data
+      end
+
+      def as_json
+        @data
+      end
+    end
+
+    raw_props = {
+      key_one: 'value1',
+      key_two: my_json_serializer.new(
+        nested_key_one: 'nested_value1',
+        nested_key_two: ['nested', 'value', 'two']
+      )
+    }
+
+    expected_params = {
+      'keyOne' => 'value1',
+      'keyTwo' => {
+        'nestedKeyOne' => 'nested_value1',
+        'nestedKeyTwo' => ['nested', 'value', 'two']
+      }
+    }
+
+    assert_equal expected_params, React.camelize_props(raw_props)
   end
 end


### PR DESCRIPTION
### Summary

This solves the case where we want to camelize_props, but those props aren't explicitly a hash or array (for example `ActiveModel::Serializer`, `Representable`, `ActionController::Parameters`, etc.

As mentioned about, I'm making the assumption that ActiveSupport is loaded since this is within Rails, but let me know if that's not a valid assumption

Also, thoughts on simplifying it even further? If we know that ActiveSupport is defined, we could just use `#deep_transform_keys` as so

```ruby
def self.camelize_props(props)
  props_as_json = props.as_json

  case props_as_json
  when Hash
    props_as_json.deep_transform_keys { |key| key.to_s.camelize(:lower) }
  when Array
    props.map { |prop| camelize_props(props) }
  else
    props
  end
end