### PR TITLE
Warn on old js runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/*/public/packs
 **/node_modules
 react-builds/build
 coverage/
+.idea/

--- a/lib/react/rails/js_runtime_checker.rb
+++ b/lib/react/rails/js_runtime_checker.rb
@@ -1,0 +1,23 @@
+module React
+  module Rails
+    module JsRuntimeChecker
+      module_function
+      def call(minimum_supported_node_version = 6)
+        node_version = ExecJS.runtime.eval('process.versions')['node']
+        node_major_version = node_version.split('.').first.to_i
+
+        if node_major_version < minimum_supported_node_version
+          warning = <<~WARNING
+            You are using node #{node_version}.
+            This an unsupported JavaScript runtime.
+            Please upgrade your node version to one >=#{minimum_supported_node_version}.
+            For more information see this issue https://git.io/fxXgI
+          WARNING
+
+          ActiveSupport::Deprecation.warn(warning)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/react/rails/js_runtime_checker.rb
+++ b/lib/react/rails/js_runtime_checker.rb
@@ -16,8 +16,10 @@ module React
 
           ActiveSupport::Deprecation.warn(warning)
         end
-      end
 
+      rescue => e
+        ActiveSupport::Deprecation.warn("Error checking JavaScript runtime: #{e.message}")
+      end
     end
   end
 end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -1,8 +1,11 @@
 require 'rails'
+require_relative 'js_runtime_checker'
 
 module React
   module Rails
     class Railtie < ::Rails::Railtie
+      JsRuntimeChecker.call
+
       config.react = ActiveSupport::OrderedOptions.new
       # Sensible defaults. Can be overridden in application.rb
       config.react.variant = (::Rails.env.production? ? :production : :development)
@@ -97,20 +100,6 @@ module React
       config.after_initialize do |app|
         # The class isn't accessible in the configure block, so assign it here if it wasn't overridden:
         app.config.react.server_renderer ||= React::ServerRendering::BundleRenderer
-
-        def yellow(message)
-           "\e[33m#{message}\e[0m"
-        end
-
-        node_version = `echo $(node -v | cut -c 2-)`.strip
-        node_major_version = node_version.sub(/\..*/, '').to_i
-
-        if node_major_version < 6
-          puts yellow("Warning: You are using node #{node_version}.")
-          puts yellow("This an unsupported JavaScript runtime.")
-          puts yellow("Please upgrade your node version to one >=6.")
-          puts yellow("For more information see this issue https://git.io/fxXgI")
-        end
 
         React::ServerRendering.pool_size        = app.config.react.server_renderer_pool_size
         React::ServerRendering.pool_timeout     = app.config.react.server_renderer_timeout

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -98,6 +98,20 @@ module React
         # The class isn't accessible in the configure block, so assign it here if it wasn't overridden:
         app.config.react.server_renderer ||= React::ServerRendering::BundleRenderer
 
+        def yellow(message)
+           "\e[33m#{message}\e[0m"
+        end
+
+        node_version = `echo $(node -v | cut -c 2-)`.strip
+        node_major_version = node_version.sub(/\..*/, '').to_i
+
+        if node_major_version < 6
+          puts yellow("Warning: You are using node #{node_version}.")
+          puts yellow("This an unsupported JavaScript runtime.")
+          puts yellow("Please upgrade your node version to one >=6.")
+          puts yellow("For more information see this issue https://git.io/fxXgI")
+        end
+
         React::ServerRendering.pool_size        = app.config.react.server_renderer_pool_size
         React::ServerRendering.pool_timeout     = app.config.react.server_renderer_timeout
         React::ServerRendering.renderer_options = app.config.react.server_renderer_options

--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
   },
   "dependencies": {
     "react_ujs": "^2.6.0"
+  },
+  "engines": {
+    "node": ">=6.0.0",
+    "yarn": ">=1.0.0"
   }
 }


### PR DESCRIPTION
Closes #948

### Summary

Added a check to see what node version is being used in `railtie.rb`. I am not a ruby/rails dev, but after some looking this seemed like an early spot to run this check. I made a custom color function as opposed to adding a library like [this](https://github.com/fazibear/colorize) one I found.

I also matched the engines in the `package.json` to those in [webpacker](https://github.com/rails/webpacker/blob/master/package.json#L10-L12)

### Other Information

A concern I would have is if this library is expected to work on non *nix environments. If that is the case then the shell commands I wrote would not work. In the node world, I would use a library like [shelljs](https://github.com/shelljs/shelljs) to handle multiple operating systems. Not sure about how this is handled in ruby.

Please let me know if that is a problem and I will fix it.

Thanks!