### PR TITLE
Fix assert_react_component test helper for multiple components page

### DIFF
--- a/lib/react/rails/test_helper.rb
+++ b/lib/react/rails/test_helper.rb
@@ -9,9 +9,7 @@ module React
       #   assert_equal "Hello world", props[:message]
       # end
       def assert_react_component(name)
-        assert_select "div[data-react-class]" do |dom|
-          assert_select "[data-react-class=?]", name
-
+        assert_select "div[data-react-class=?]", name do |dom|
           if block_given?
             props = JSON.parse(dom.attr("data-react-props"))
             props.deep_transform_keys! { |key| key.to_s.underscore }

--- a/test/react/rails/test_helper_test.rb
+++ b/test/react/rails/test_helper_test.rb
@@ -13,5 +13,8 @@ class TestHelperTest < ActionDispatch::IntegrationTest
       assert_select "[id=?]", "component"
       assert_select "[class=?]", "greeting-message"
     end
+    assert_react_component "Todo" do |props|
+      assert_equal "Another Component", props[:todo]
+    end
   end
 end


### PR DESCRIPTION
Last  commit https://github.com/reactjs/react-rails/commit/71ced0c2ac5b86c9393a5476436bf25a61786983 have bug.

When the page have more than one React Component, `assert_react_component` can't catch the next items.