### PR TITLE
Enhanced turbolinks support

### DIFF
--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -15,6 +15,7 @@ module React
       # You can use them in custom helper implementations
       def setup(controller)
         @controller = controller
+        @cache_ids = []
       end
 
       def teardown(controller)
@@ -40,6 +41,9 @@ module React
             data[:react_class] = name
             data[:react_props] = (props.is_a?(String) ? props : props.to_json)
             data[:hydrate] = 't' if prerender_options
+
+            num_components = @cache_ids.count { |c| c.start_with? name }
+            data[:react_cache_id] = "#{name}-#{num_components}"
           end
         end
         html_tag = html_options[:tag] || :div

--- a/lib/react/rails/component_mount.rb
+++ b/lib/react/rails/component_mount.rb
@@ -11,11 +11,14 @@ module React
       attr_accessor :output_buffer
       mattr_accessor :camelize_props_switch
 
+      def initialize
+        @cache_ids = []
+      end
+
       # {ControllerLifecycle} calls these hooks
       # You can use them in custom helper implementations
       def setup(controller)
         @controller = controller
-        @cache_ids = []
       end
 
       def teardown(controller)

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -21,6 +21,8 @@ var ReactRailsUJS = {
   // A unique identifier to identify a node
   CACHE_ID_ATTR: "data-react-cache-id",
 
+  TURBOLINKS_PERMANENT_ATTR: "data-turbolinks-permanent",
+
   // If jQuery is detected, save a reference to it for event handlers
   jQuery: (typeof window !== 'undefined') && (typeof window.jQuery !== 'undefined') && window.jQuery,
 
@@ -92,6 +94,7 @@ var ReactRailsUJS = {
       var props = propsJson && JSON.parse(propsJson);
       var hydrate = node.getAttribute(ReactRailsUJS.RENDER_ATTR);
       var cacheId = node.getAttribute(ujs.CACHE_ID_ATTR);
+      var turbolinksPermanent = node.hasAttribute(ujs.TURBOLINKS_PERMANENT_ATTR);
 
       if (!constructor) {
         var message = "Cannot find component: '" + className + "'"
@@ -103,7 +106,9 @@ var ReactRailsUJS = {
         let component = this.components[cacheId];
         if(component === undefined) {
           component = React.createElement(constructor, props);
-          this.components[cacheId] = component;
+          if(turbolinksPermanent) {
+            this.components[cacheId] = component;
+          }
         }
 
         if (hydrate && typeof ReactDOM.hydrate === "function") {

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -92,7 +92,7 @@ var ReactRailsUJS = {
       var constructor = ujs.getConstructor(className);
       var propsJson = node.getAttribute(ujs.PROPS_ATTR);
       var props = propsJson && JSON.parse(propsJson);
-      var hydrate = node.getAttribute(ReactRailsUJS.RENDER_ATTR);
+      var hydrate = node.getAttribute(ujs.RENDER_ATTR);
       var cacheId = node.getAttribute(ujs.CACHE_ID_ATTR);
       var turbolinksPermanent = node.hasAttribute(ujs.TURBOLINKS_PERMANENT_ATTR);
 

--- a/react_ujs/src/events/turbolinks.js
+++ b/react_ujs/src/events/turbolinks.js
@@ -1,12 +1,12 @@
 module.exports = {
   // Turbolinks 5+ got rid of named events (?!)
   setup: function(ujs) {
-    ujs.handleEvent('turbolinks:load', ujs.handleMount)
-    ujs.handleEvent('turbolinks:before-render', ujs.handleUnmount)
+  	ujs.handleEvent('turbolinks:load', ujs.handleMount);
+    ujs.handleEvent('turbolinks:before-render', ujs.handleMount);
   },
 
   teardown: function(ujs) {
-    ujs.removeEvent('turbolinks:load', ujs.handleMount)
-    ujs.removeEvent('turbolinks:before-render', ujs.handleUnmount)
+  	ujs.removeEvent('turbolinks:load', ujs.handleMount);
+    ujs.removeEvent('turbolinks:before-render', ujs.handleMount);
   },
 }

--- a/test/react/rails/view_helper_test.rb
+++ b/test/react/rails/view_helper_test.rb
@@ -32,7 +32,7 @@ class ViewHelperTest < ActionView::TestCase
   test 'view helper can accept block and render inner content only once' do
     rendered_html = render partial: 'pages/component_with_inner_html'
     expected_html = <<HTML
-<div data-react-class=\"GreetingMessage\" data-react-props=\"{&quot;name&quot;:&quot;Name&quot;}\" id=\"component\" data-react-cache-id=\"GreetingMessage-0\">
+<div data-react-class=\"GreetingMessage\" data-react-props=\"{&quot;name&quot;:&quot;Name&quot;}\" data-react-cache-id=\"GreetingMessage-0\" id=\"component\">
   <div id=\"unique-nested-id\">NestedContent</div>
 </div>
 HTML

--- a/test/react/rails/view_helper_test.rb
+++ b/test/react/rails/view_helper_test.rb
@@ -10,13 +10,13 @@ end
 
 class ViewHelperTest < ActionView::TestCase
   test 'view helper can be called directly' do
-    expected_html = %{<div data-react-class="Component" data-react-props="{&quot;a&quot;:&quot;b&quot;}"></div>}
+    expected_html = %{<div data-react-class="Component" data-react-props="{&quot;a&quot;:&quot;b&quot;}" data-react-cache-id="Component-0"></div>}
     rendered_html = ViewHelperHelper.react_component('Component', { a: 'b' })
     assert_equal(expected_html, rendered_html)
   end
 
   test 'view helper accepts block usage' do
-    expected_html = %{<div data-react-class="Component" data-react-props="{&quot;a&quot;:&quot;b&quot;}">content</div>}
+    expected_html = %{<div data-react-class="Component" data-react-props="{&quot;a&quot;:&quot;b&quot;}" data-react-cache-id="Component-0">content</div>}
     rendered_html = ViewHelperHelper.react_component('Component', { a: 'b' }) do
       'content'
     end
@@ -32,7 +32,7 @@ class ViewHelperTest < ActionView::TestCase
   test 'view helper can accept block and render inner content only once' do
     rendered_html = render partial: 'pages/component_with_inner_html'
     expected_html = <<HTML
-<div data-react-class=\"GreetingMessage\" data-react-props=\"{&quot;name&quot;:&quot;Name&quot;}\" id=\"component\">
+<div data-react-class=\"GreetingMessage\" data-react-props=\"{&quot;name&quot;:&quot;Name&quot;}\" id=\"component\" data-react-cache-id=\"GreetingMessage-0\">
   <div id=\"unique-nested-id\">NestedContent</div>
 </div>
 HTML


### PR DESCRIPTION
### Summary

This does 2 things. 

The first is move the mounting to `turbolinks:before-render`, since that's the earliest event where the user sees content on the page. When it was set to `load` only, the user wouldn't see any react components until the network request finished, rather than seeing them on the cached page. This fixes #960 

The second caches rendered components. If you pass an existing component to ReactDOM, it will update the currently mounted component with the passed component, rather than replacing it.
This allows the `data-turbolinks-permanent` attribute to work correct. When the cached page is displayed and react_ujs mounts the existing component, it won't destroy the cached component.

This lets you do things like have react components in your layout that aren't affected by page changes, like a navigation component, or search popup. 

An example where the navbar/appbar is permanent, but the main page is not:

![mk2aly1ba2](https://user-images.githubusercontent.com/1729810/52155926-8c587e80-265b-11e9-9278-0a9fd5b295e8.gif)

