### PR TITLE
 ✅ Update controller test to use `params:` when Rails 4+

### DIFF
--- a/test/react/rails/pages_controller_test.rb
+++ b/test/react/rails/pages_controller_test.rb
@@ -13,16 +13,16 @@ class PagesControllerTest < ActionController::TestCase
 
   when_stateful_js_context_available do
     test 'it sets up and tears down a react context' do
-      get :show, id: 1, prerender: true
+      get :show, query_params(id: 1, prerender: true)
       assert_includes(response.body, 'Hello')
 
-      get :show, id: 1, prerender: true, greeting: 'Howdy'
+      get :show, query_params(id: 1, prerender: true, greeting: 'Howdy')
       assert_includes(response.body, 'Howdy')
 
-      get :show, id: 1, prerender: true, greeting: '👋'
+      get :show, query_params(id: 1, prerender: true, greeting: '👋')
       assert_includes(response.body, '👋')
 
-      get :show, id: 1, prerender: true
+      get :show, query_params(id: 1, prerender: true)
       assert_includes(response.body, 'Hello')
     end
   end
@@ -30,9 +30,9 @@ class PagesControllerTest < ActionController::TestCase
   WebpackerHelpers.when_webpacker_available do
     test 'it mounts components from the dev server' do
       WebpackerHelpers.with_dev_server do
-        get :show, id: 1, prerender: true
+        get :show, query_params(id: 1, prerender: true)
         assert_match /Hello<!--.*--> from Webpacker/, response.body
-        get :show, id: 1, prerender: true, greeting: 'Howdy'
+        get :show, query_params(id: 1, prerender: true, greeting: 'Howdy')
         assert_match /Howdy<!--.*--> from Webpacker/, response.body
       end
     end


### PR DESCRIPTION
### Summary

Tests were failing on Rails 5.2 because of an error introduced earlier where controller tests introduced did not make use of the provided params helpers. 