### PR TITLE
Fix/assert react component with multiple case

### DIFF
--- a/lib/react/rails/test_helper.rb
+++ b/lib/react/rails/test_helper.rb
@@ -9,9 +9,7 @@ module React
       #   assert_equal "Hello world", props[:message]
       # end
       def assert_react_component(name)
-        assert_select "div[data-react-class]" do |dom|
-          assert_select "[data-react-class=?]", name
-
+        assert_select "div[data-react-class=?]", name do |dom|
           if block_given?
             props = JSON.parse(dom.attr("data-react-props"))
             props.deep_transform_keys! { |key| key.to_s.underscore }

--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -79,7 +79,7 @@ module React
         end
       elsif MAJOR >= 3
         def file_path path
-          ::Rails.root.join('public', manifest.lookup(path)[1..-1])
+          ::Rails.root.join('public', manifest.lookup!(path)[1..-1])
         end
       else # 1.0 and 1.1 support
         def file_path path

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "devDependencies": {
     "webpack": "^2.3.3"
+  },
+  "dependencies": {
+    "react_ujs": "^2.4.4"
   }
 }

--- a/test/dummy_webpacker1/app/views/pages/show.html.erb
+++ b/test/dummy_webpacker1/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { name: @name }, { id: 'component', prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name, last_name: "Last #{@name}", info: { name: @name } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
   <ul>
     <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
   </ul>

--- a/test/dummy_webpacker2/app/views/pages/show.html.erb
+++ b/test/dummy_webpacker2/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { name: @name }, { id: 'component', prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name, last_name: "Last #{@name}", info: { name: @name } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
   <ul>
     <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
   </ul>

--- a/test/dummy_webpacker3/app/views/pages/show.html.erb
+++ b/test/dummy_webpacker3/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { name: @name }, { id: 'component', prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name, last_name: "Last #{@name}", info: { name: @name } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
   <ul>
     <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
   </ul>

--- a/test/react/rails/test_helper_test.rb
+++ b/test/react/rails/test_helper_test.rb
@@ -13,5 +13,8 @@ class TestHelperTest < ActionDispatch::IntegrationTest
       assert_select "[id=?]", "component"
       assert_select "[class=?]", "greeting-message"
     end
+    assert_react_component "Todo" do |props|
+      assert_equal "Another Component", props[:todo]
+    end
   end
 end

--- a/test/react/rails/test_helper_test.rb
+++ b/test/react/rails/test_helper_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class TestHelperTest < ActionDispatch::IntegrationTest
+  setup do
+    WebpackerHelpers.compile_if_missing
+  end
+
   test 'assert_react_component' do
     get "/pages/1"
     assert_equal 200, response.status

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,6 +1314,11 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react_ujs@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/react_ujs/-/react_ujs-2.4.4.tgz#49bac535d24024a96b0a35d7514d18188aea42bc"
+  integrity sha512-RON6mgV+I3s6KkmvxTQi+WGuoLbhZ+TzRat06EE/RHFvzU+Na1Eom6XnesQeOP7WCrTZGOdcZEPP0P7QrJrHfg==
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"


### PR DESCRIPTION
### Summary

Extension to #961

This corrects the issue of webpacker 3 appearing to not compile when it was an execution-order dependent test. This was fixed by the `WebpackerHelpers.compile_if_missing` entry.

This includes extensions to test views in `{ name: @name, last_name: "Last #{@name}", info: { name: @name } }`  which completes the above linked PR.