### PR TITLE
Keep variable name case sensitive on assert_react_component props.

### DIFF
--- a/lib/react/rails/test_helper.rb
+++ b/lib/react/rails/test_helper.rb
@@ -12,7 +12,6 @@ module React
         assert_select "div[data-react-class=?]", name do |dom|
           if block_given?
             props = JSON.parse(dom.attr("data-react-props"))
-            props.deep_transform_keys! { |key| key.to_s.underscore }
             props.deep_symbolize_keys!
 
             yield(props)

--- a/test/dummy_sprockets/app/views/pages/show.html.erb
+++ b/test/dummy_sprockets/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { name: @name, last_name: "Last #{@name}", info: { name: @name } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name, lastName: "Last #{@name}", info: { name: @name, lastName: "Last #{@name}" } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
   <ul>
     <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
   </ul>

--- a/test/dummy_webpacker1/app/views/pages/show.html.erb
+++ b/test/dummy_webpacker1/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { name: @name, last_name: "Last #{@name}", info: { name: @name } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name, lastName: "Last #{@name}", info: { name: @name, lastName: "Last #{@name}" } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
   <ul>
     <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
   </ul>

--- a/test/dummy_webpacker2/app/views/pages/show.html.erb
+++ b/test/dummy_webpacker2/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { name: @name, last_name: "Last #{@name}", info: { name: @name } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name, lastName: "Last #{@name}", info: { name: @name, lastName: "Last #{@name}" } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
   <ul>
     <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
   </ul>

--- a/test/dummy_webpacker3/app/views/pages/show.html.erb
+++ b/test/dummy_webpacker3/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </ul>
 
 <div id='component-parent'>
-  <%= react_component 'GreetingMessage', { name: @name, last_name: "Last #{@name}", info: { name: @name } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
+  <%= react_component 'GreetingMessage', { name: @name, lastName: "Last #{@name}", info: { name: @name, lastName: "Last #{@name}" } }, { id: 'component', class: "greeting-message", prerender: @prerender } %>
   <ul>
     <%= react_component 'Todo', { todo: 'Another Component' }, { id: 'todo', prerender: @prerender } %>
   </ul>

--- a/test/react/rails/test_helper_test.rb
+++ b/test/react/rails/test_helper_test.rb
@@ -11,8 +11,9 @@ class TestHelperTest < ActionDispatch::IntegrationTest
     assert_react_component "GreetingMessage"
     assert_react_component "GreetingMessage" do |props|
       assert_equal "Bob", props[:name]
-      assert_equal "Last Bob", props[:last_name]
+      assert_equal "Last Bob", props[:lastName]
       assert_equal "Bob", props[:info][:name]
+      assert_equal "Last Bob", props[:info][:lastName]
 
       assert_select "[id=?]", "component"
       assert_select "[class=?]", "greeting-message"


### PR DESCRIPTION
We need make sure the prop name is correct, because JavaScript used that it's case sensitive.

for example:

```erb
<%= react_component "InlineEditor", name: "comment[body_sml]", directUploadURL: rails_direct_uploads_url, blobURLTemplate: "/uploads/:id" %>
```

```jsx
const InlineEditor extends Component {
  render() {
    const { directUploadURL, blobURLTemplate } = this.props;
  }
}
```

@BookOfGreg 