### PR TITLE
Update README.md: Webpacker 4.x supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 React-Rails is a flexible tool to use [React](http://facebook.github.io/react/) with Rails. The benefits:
 * Automatically renders React server-side and client-side
-* Supports Webpacker 3.x, 2.x, 1.1+
+* Supports Webpacker 4.x, 3.x, 2.x, 1.1+
 * Supports Sprockets 4.x, 3.x, 2.x
 * Lets you use [JSX](http://facebook.github.io/react/docs/jsx-in-depth.html), [ES6](http://es6-features.org/), [TypeScript](https://www.typescriptlang.org/), [CoffeeScript](http://coffeescript.org/)
 


### PR DESCRIPTION
### Summary

After https://github.com/reactjs/react-rails/pull/934/files#diff-3bb7346aca79d8142e16e61372bd04dcR14 was merged, i'm guessing that means Webpacker 4.x is actually supported now? README didn't say it was though.

Related:
- https://github.com/reactjs/react-rails/issues/918
- https://github.com/reactjs/react-rails/pull/934
- https://github.com/reactjs/react-rails/issues/939