### PR TITLE
Typescript component generator

### DIFF
--- a/lib/generators/react/component_generator.rb
+++ b/lib/generators/react/component_generator.rb
@@ -55,6 +55,11 @@ module React
                    default: false,
                    desc: 'Output es6 class based component'
 
+      class_option :ts,
+                   type: :boolean,
+                   default: false,
+                   desc: 'Output tsx class based component'
+
       class_option :coffee,
                    type: :boolean,
                    default: false,
@@ -92,6 +97,8 @@ module React
       def create_component_file
         template_extension = if options[:coffee]
           'js.jsx.coffee'
+        elsif options[:ts]
+          'js.jsx.tsx'
         elsif options[:es6] || webpacker?
           'es6.jsx'
         else
@@ -101,7 +108,12 @@ module React
         # Prefer webpacker to sprockets:
         if webpacker?
           new_file_name = file_name.camelize
-          extension = options[:coffee] ? 'coffee' : 'js'
+          extension = if options[:coffee]
+            'coffee'
+          elsif options[:ts]
+            'tsx'
+          else
+            'js'
           target_dir = webpack_configuration.source_path
             .join('components')
             .relative_path_from(::Rails.root)
@@ -129,6 +141,8 @@ module React
       def file_header
         if webpacker?
           %|import React from "react"\nimport PropTypes from "prop-types"\n|
+        elsif options[:ts]
+          %|import * as React from "react"\n|
         else
           ''
         end

--- a/lib/generators/react/component_generator.rb
+++ b/lib/generators/react/component_generator.rb
@@ -94,6 +94,33 @@ module React
         }
       }
 
+      TYPESCRIPT_TYPES = {
+        'node' =>        'React.ReactNode',
+        'bool' =>        'boolean',
+        'boolean' =>     'boolean',
+        'string' =>      'string',
+        'number' =>      'number',
+        'object' =>      'object',
+        'array' =>       'Array<any>',
+        'shape' =>       'object',
+        'element' =>     'object',
+        'func' =>        'object',
+        'function' =>    'object',
+        'any' =>         'any',
+
+        'instanceOf' => ->(type) {
+          type.to_s.camelize
+        },
+
+        'oneOf' => ->(*opts) {
+          opts.map{ |k| "'#{k.to_s}'" }.join(" | ")
+        },
+
+        'oneOfType' => ->(*opts) {
+          opts.map{ |k| "#{ts_lookup(k.to_s, k.to_s)}" }.join(" | ")
+        }
+      }
+
       def create_component_file
         template_extension = if options[:coffee]
           'js.jsx.coffee'
@@ -114,6 +141,7 @@ module React
             'tsx'
           else
             'js'
+          end
           target_dir = webpack_configuration.source_path
             .join('components')
             .relative_path_from(::Rails.root)
@@ -140,9 +168,8 @@ module React
 
       def file_header
         if webpacker?
+          return %|import * as React from "react"\n| if options[:ts]
           %|import React from "react"\nimport PropTypes from "prop-types"\n|
-        elsif options[:ts]
-          %|import * as React from "react"\n|
         else
           ''
         end
@@ -160,23 +187,58 @@ module React
         defined?(Webpacker)
       end
 
-       def parse_attributes!
-         self.attributes = (attributes || []).map do |attr|
-           name = ''
-           type = ''
-           options = ''
-           options_regex = /(?<options>{.*})/
+      def parse_attributes!
+        self.attributes = (attributes || []).map do |attr|
+          name = ''
+          type = ''
+          args = ''
+          args_regex = /(?<args>{.*})/
 
-           name, type = attr.split(':')
+          name, type = attr.split(':')
 
-           if matchdata = options_regex.match(type)
-             options = matchdata[:options]
-             type = type.gsub(options_regex, '')
-           end
+          if matchdata = args_regex.match(type)
+            args = matchdata[:args]
+            type = type.gsub(args_regex, '')
+          end
 
-           { :name => name, :type => lookup(type, options) }
-         end
-       end
+          if options[:ts]
+            { :name => name, :type => ts_lookup(name, type, args), :union => union?(args) }
+          else
+            { :name => name, :type => lookup(type, args) }
+          end
+        end
+      end
+
+      def union?(args = '')
+        return args.to_s.gsub(/[{}]/, '').split(',').count > 1
+      end
+
+      def self.ts_lookup(name, type = 'node', args = '')
+        ts_type = TYPESCRIPT_TYPES[type]
+        if ts_type.blank?
+          if type =~ /^[[:upper:]]/
+            ts_type = TYPESCRIPT_TYPES['instanceOf']
+          else
+            ts_type = TYPESCRIPT_TYPES['node']
+          end
+        end
+
+        args = args.to_s.gsub(/[{}]/, '').split(',')
+
+        if ts_type.respond_to? :call
+          if args.blank?
+            return ts_type.call(type)
+          end
+
+          ts_type = ts_type.call(*args)
+        end
+
+        ts_type
+      end
+
+      def ts_lookup(name, type = 'node', args = '')
+        self.class.ts_lookup(name, type, args)
+      end
 
        def self.lookup(type = 'node', options = '')
          react_prop_type = REACT_PROP_TYPES[type]

--- a/lib/generators/templates/component.js.jsx.tsx
+++ b/lib/generators/templates/component.js.jsx.tsx
@@ -1,21 +1,34 @@
 <%= file_header %>
+<% unions = attributes.select{ |a| a[:union] } -%>
+<% if unions.size > 0 -%>
+<% unions.each do |e| -%>
+type <%= e[:name].titleize %> = <%= e[:type]%>
+<% end -%>
+<% end -%>
+
 interface I<%= component_name %>Props {
 <% if attributes.size > 0 -%>
-  <% attributes.each_with_index do | attribute, idx | -%>
-    <%= attribute[:name].camelize(:lower) %>?: <%= attribute[:type] %>;
-  <% end -%>
+<% attributes.each do | attribute | -%>
+<% if attribute[:union] -%>
+  <%= attribute[:name].camelize(:lower) %>: <%= attribute[:name].titleize %>;
+<% else -%>
+  <%= attribute[:name].camelize(:lower) %>: <%= attribute[:type] %>;
+<% end -%>
+<% end -%>
 <% end -%>
 }
+
 interface I<%= component_name %>State {
 }
+
 class <%= component_name %> extends React.Component <I<%= component_name %>Props, I<%= component_name %>State> {
   render() {
     return (
       <React.Fragment>
-        <% attributes.each do |attribute| -%>
-          <%= attribute[:name].titleize %>: {this.props.<%= attribute[:name].camelize(:lower) %>}
-        <% end -%>
-      </React.Fragment>
+  <% attributes.each do |attribute| -%>
+      <%= attribute[:name].titleize %>: {this.props.<%= attribute[:name].camelize(:lower) %>}
+  <% end -%>
+    </React.Fragment>
     );
   }
 }

--- a/lib/generators/templates/component.js.jsx.tsx
+++ b/lib/generators/templates/component.js.jsx.tsx
@@ -1,0 +1,23 @@
+<%= file_header %>
+interface I<%= component_name %>Props {
+<% if attributes.size > 0 -%>
+  <% attributes.each_with_index do | attribute, idx | -%>
+    <%= attribute[:name].camelize(:lower) %>?: <%= attribute[:type] %>;
+  <% end -%>
+<% end -%>
+}
+interface I<%= component_name %>State {
+}
+class <%= component_name %> extends React.Component <I<%= component_name %>Props, I<%= component_name %>State> {
+  render() {
+    return (
+      <React.Fragment>
+        <% attributes.each do |attribute| -%>
+          <%= attribute[:name].titleize %>: {this.props.<%= attribute[:name].camelize(:lower) %>}
+        <% end -%>
+      </React.Fragment>
+    );
+  }
+}
+
+<%= file_footer %>


### PR DESCRIPTION
## Summary

Allow the generation of typescript components by passing the `--ts` flag to the generator

resolves #965 

### Other information
Also handles all the special prop types like `instanceOf`, `oneOf`, and `oneOfType`:
- Treat instanceOf prop types as reference to predefined types.
- Treat oneOf prop types as union types, and define the union type.
- Treat oneOfType prop types as union of primitives and custom types, and define both custom type and union type

#### Example
```bash
$ bin/rails g react:component HelloWorld greeting:string \
  'food:oneOf{meat,cheese,vegetable}' \
  'cuisine:oneOfType{string,Food}' \
  owner:instanceOf{Person} --ts
      create  app/javascript/components/HelloWorld.tsx
```

```typescript
// app/javascript/components/HelloWorld.tsx
import * as React from "react"

type Food = 'meat' | 'cheese' | 'vegetable'
type Cuisine = string | Food

interface IHelloWorldProps {
  greeting: string;
  food: Food;
  cuisine: Cuisine;
  owner: Person;
}

interface IHelloWorldState {
}

class HelloWorld extends React.Component <IHelloWorldProps, IHelloWorldState> {
  render() {
    return (
      <React.Fragment>
        Greeting: {this.props.greeting}
        Food: {this.props.food}
        Cuisine: {this.props.cuisine}
        Owner: {this.props.owner}
      </React.Fragment>
    );
  }
}

export default HelloWorld
```