### PR TITLE
Only include React::Rails::TestHelper in test environment

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -58,7 +58,7 @@ module React
 
         ActiveSupport.on_load(:action_view) do
           include ::React::Rails::ViewHelper
-          ActionDispatch::IntegrationTest.send(:include, React::Rails::TestHelper)
+          ActionDispatch::IntegrationTest.send(:include, React::Rails::TestHelper) if ::Rails.env.test?
         end
       end
 


### PR DESCRIPTION
Based on [this discussion in the rails repository](https://github.com/rails/rails/issues/31200) I determined that the latest version of `react-rails` (2.5.0, not present in 2.4.7) inadvertently causes `action_controller/test_case` to be required, which breaks `ActionController::Live` streaming in development and presumably production environments.

```ruby
/home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/actionpack-5.2.3/lib/action_controller/test_case.rb:23:in `<module:Live>'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/actionpack-5.2.3/lib/action_controller/test_case.rb:18:in `<module:ActionController>'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/actionpack-5.2.3/lib/action_controller/test_case.rb:13:in `<top (required)>'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/actionpack-5.2.3/lib/action_dispatch/testing/integration.rb:614:in `<module:Behavior>'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/actionpack-5.2.3/lib/action_dispatch/testing/integration.rb:610:in `<class:IntegrationTest>'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/actionpack-5.2.3/lib/action_dispatch/testing/integration.rb:600:in `<module:ActionDispatch>'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/actionpack-5.2.3/lib/action_dispatch/testing/integration.rb:12:in `<top (required)>'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
  /home/john/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/react-rails-2.5.0/lib/react/rails/railtie.rb:61:in `block (2 levels) in <class:Railtie>'
```

This change only includes `React::Rails::TestHelper` in the test environment.