### PR TITLE
Bump version for UJS to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### New Features
 
 - Typescript component generator #990
+- Enhanced Turbolinks Support #978 #962
 
 #### Deprecation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react_ujs",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Rails UJS for the react-rails gem",
   "main": "react_ujs/index.js",
   "files": [
@@ -14,6 +14,6 @@
     "webpack": "^2.3.3"
   },
   "dependencies": {
-    "react_ujs": "^2.5.0"
+    "react_ujs": "^2.6.0"
   }
 }


### PR DESCRIPTION
### Summary

Closes #1008 
This releases 2.6.0 of the UJS which releases the good work done on additional Turbolinks support.