### PR TITLE
modified installation instructions for rails6

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ gem 'react-rails'
 ```
 
 ##### 3) Now run the installers:
+
+###### Rails 6.x:
+```
+$ bundle install
+$ rails webpacker:install:react
+$ rails generate react:install
+```
+
+###### Rails 5.x:
 ```
 $ bundle install
 $ rails webpacker:install       # OR (on rails version < 5.0) rake webpacker:install
@@ -658,7 +667,7 @@ yarn install
 ### Undefined Set
 ```
 ExecJS::ProgramError (identifier 'Set' undefined):
-  
+
 (execjs):1
 ```
 If you see any variation of this issue, see [Using TheRubyRacer](#using-therubyracer)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $ bundle install
 $ rails webpacker:install:react
 $ rails generate react:install
 ```
+Note: For Rails 6, You don't need to add `javascript_pack_tag` as in Step 4. Since its already added by default.
 
 ###### Rails 5.x:
 ```


### PR DESCRIPTION
### Summary

Modified installation instructions for Rails 6 🎉

### Other Information

Rails 6 now ships with webpacker as default JS compiler. See:  https://github.com/rails/rails/pull/33079