### PR TITLE
Call handleUnmount before rendering a new page

### DIFF
--- a/react_ujs/src/events/turbolinks.js
+++ b/react_ujs/src/events/turbolinks.js
@@ -2,11 +2,11 @@ module.exports = {
   // Turbolinks 5+ got rid of named events (?!)
   setup: function(ujs) {
   	ujs.handleEvent('turbolinks:load', ujs.handleMount);
-    ujs.handleEvent('turbolinks:before-render', ujs.handleMount);
+    ujs.handleEvent('turbolinks:before-render', ujs.handleUnmount);
   },
 
   teardown: function(ujs) {
   	ujs.removeEvent('turbolinks:load', ujs.handleMount);
-    ujs.removeEvent('turbolinks:before-render', ujs.handleMount);
+    ujs.removeEvent('turbolinks:before-render', ujs.handleUnmount);
   },
 }


### PR DESCRIPTION
### Summary

UJS would mount non permanent react components multiple times when navigating away and then back to a page with one.

### Other Information

This was modified back in July in [this commit](https://github.com/reactjs/react-rails/commit/4dbcd6756dcd09c312abf95a73cbb6026f3f9a69#diff-caee293a420e16032c5cec4539620c8b). It appears as if it might have been modified unintentionally.

