### PR TITLE
Fix compatibility with beta versions of Sprockets

### DIFF
--- a/lib/react/jsx/sprockets_strategy.rb
+++ b/lib/react/jsx/sprockets_strategy.rb
@@ -23,7 +23,7 @@ module React
       # @return [Symbol] based on the environment, return a method name to call with the sprockets environment
       def detect_strategy
         sprockets_version = Gem::Version.new(Sprockets::VERSION)
-        if sprockets_version >= Gem::Version.new('4.x')
+        if sprockets_version >= Gem::Version.new('4.a')
           :register_processors
         elsif sprockets_version >= Gem::Version.new('3.0.0')
           :register_engine_with_mime_type


### PR DESCRIPTION
RubyGems made a change that causes this error when you're on a beta version of Sprockets 4:

    /home/vagrant/code/rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/react-rails-2.6.0/lib/react/jsx/sprockets_strategy.rb:40:in
    `register_engine_with_mime_type': undefined method `register_engine' for Sprockets:Module (NoMethodError)

Here's the relevant commit:

https://github.com/rubygems/rubygems/commit/9836549344ace8ee822da0a5157d2810670e3bde#diff-94d386526b8b558035d4e4c7602d647c

And here's how the behavior of `Gemf::Version#<=>` has changed:

Before:

    1:(main)> `gem --version`
    => "3.0.3\n"
    2:(main)> Gem::Version.new("4.0.0.beta9") >= Gem::Version.new('4.x')
    => true
    3:(main)> Gem::Version.new("4.0.0.beta9") >= Gem::Version.new('4.a')
    => true

After:

    1:(main)> `gem --version`
    => "3.1.2\n"
    2:(main)> Gem::Version.new("4.0.0.beta9") >= Gem::Version.new('4.x')
    => false
    3:(main)> Gem::Version.new("4.0.0.beta9") >= Gem::Version.new('4.a')
    => true

Sprockets 4.0 is out now, but this is still a bug, and people shouldn't be forced to upgrade because of it.