### PR TITLE
Typescript support section: mention server_renderer_extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ $ bundle exec rails webpacker:install:typescript
 $ yarn add @types/react @types/react-dom
 ```
 
-Doing this will allow React-Rails to support the .tsx extension.
+Doing this will allow React-Rails to support the .tsx extension. Additionally, it is recommended to add `ts` and `tsx` to the `server_renderer_extensions` in your application configuration:
+```
+config.react.server_renderer_extensions = ["jsx", "js", "tsx", "ts"]
+```
 
 ### Test component
 


### PR DESCRIPTION
Recommend setting the `server_renderer_extensions` config option in the Typescript support section.

I experienced issues with changes to `tsx` and `ts` files not being properly updated in development. After loads of research on various levels of setup, I ran into [this issue](https://github.com/reactjs/react-rails/issues/1049#issuecomment-584993650), which thankfully had a fix (I felt equally stupid as the author). I'd say typescript support is incomplete without the `server_renderer_extensions` config. Anything else delivers a subpar development experience.

I hope you sill consider my addition to the README, and thanks for all the work you put into this lib 👍 