### PR TITLE
Fix Warning/Error Caused by URI.open instead of open

### DIFF
--- a/lib/react/server_rendering/webpacker_manifest_container.rb
+++ b/lib/react/server_rendering/webpacker_manifest_container.rb
@@ -27,7 +27,7 @@ module React
           asset_path = manifest.lookup(logical_path).to_s
           if asset_path.start_with?('http')
             # Get a file from the webpack-dev-server
-            dev_server_asset = open(asset_path).read
+            dev_server_asset = URI.open(asset_path).read
             # Remove `webpack-dev-server/client/index.js` code which causes ExecJS to 💥
             dev_server_asset.sub!(CLIENT_REQUIRE, '//\0')
             dev_server_asset
@@ -44,7 +44,7 @@ module React
             ds = Webpacker.dev_server
             # Remove the protocol and host from the asset path. Sometimes webpacker includes this, sometimes it does not
             asset_path.slice!("#{ds.protocol}://#{ds.host_with_port}")
-            dev_server_asset = open("#{ds.protocol}://#{ds.host_with_port}#{asset_path}").read
+            dev_server_asset = URI.open("#{ds.protocol}://#{ds.host_with_port}#{asset_path}").read
             dev_server_asset.sub!(CLIENT_REQUIRE, '//\0')
             dev_server_asset
           else

--- a/test/support/webpacker_helpers.rb
+++ b/test/support/webpacker_helpers.rb
@@ -101,7 +101,7 @@ module WebpackerHelpers
       return false unless example_asset_path
       return false unless example_asset_path.start_with?('http://localhost:8080')
       begin
-        file = open('http://localhost:8080/packs/application.js')
+        file = URI.open('http://localhost:8080/packs/application.js')
       rescue StandardError => e
         file = nil
       end
@@ -134,7 +134,7 @@ module WebpackerHelpers
       example_asset_path = manifest_data.values.first
       return false unless example_asset_path
       begin
-        file = open("#{ds.protocol}://#{ds.host}:#{ds.port}#{example_asset_path}")
+        file = URI.open("#{ds.protocol}://#{ds.host}:#{ds.port}#{example_asset_path}")
       rescue StandardError => e
         file = nil
       end


### PR DESCRIPTION
### Summary

Using open via the following snippet:

    require 'open-uri'
    open('https//...')

In ruby 2 results in the following deprecation warning:

    warning: calling URI.open via Kernel#open is deprecated
    call URI.open directly or use URI#open

In ruby 3 results in the following exception:

    Errno::ENOENT (No such file or directory @ rb_sysopen - https://...)

The fixes by calling open through URI.
