### PR TITLE
📝: Update README.md [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ $ cd my-app
 gem 'webpacker'
 gem 'react-rails'
 ```
+Note: For Rails 6, You don't need to add `gem 'webpacker'` to your gemfile in step 2 above.
+Webpacker is the default javascript compiler for Rails 6, and is already added to your gemfile
+when you create a new app.
 
 ##### 3) Now run the installers:
 


### PR DESCRIPTION
### Summary

Added a note to point 2 of the header 'Get Started With Webpacker'.
For Rails 6, the line `gem 'webpacker'` is not needed in the gemfile, as
it is already added by default.

### Other Information

Leaving in the line generates an error when bundle install is run:
"You cannot specify the same gem twice with different version requirements. 
You specified: webpacker (>= 0) and webpacker (~> 4.0)" 
