### PR TITLE
fix(README): clearer instructions in steps 3 and 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,18 @@ gem 'react-rails'
 
 ##### 3) Now run the installers:
 
-###### Rails 6.x:
+###### Rails 5.x, 6.x:
 ```
 $ bundle install
 $ rails webpacker:install
 $ rails webpacker:install:react
 $ rails generate react:install
 ```
-Note: For Rails 6, You don't need to add `javascript_pack_tag` as in Step 4. Since its already added by default.
-
-###### Rails 5.x:
+###### Rails < 5.x:
 ```
 $ bundle install
-$ rails webpacker:install       # OR (on rails version < 5.0) rake webpacker:install
-$ rails webpacker:install:react # OR (on rails version < 5.0) rake webpacker:install:react
+$ rake webpacker:install
+$ rake webpacker:install:react
 $ rails generate react:install
 ```
 This gives you:
@@ -98,6 +96,9 @@ This gives you:
 - `app/javascript/packs/server_rendering.js` for [server-side rendering](#server-side-rendering)
 
 ##### 4) Link the JavaScript pack in Rails view using `javascript_pack_tag` [helper](https://github.com/rails/webpacker#usage):
+
+Note: For Rails 6 this step can be skipped, since `javascript_pack_tag` is added by default.
+
 ```erb
 <!-- application.html.erb in Head tag below turbolinks -->
 <%= javascript_pack_tag 'application' %>


### PR DESCRIPTION
It was confusing to have a section in Step 3 which made reference to Rails 5.x and then have comments about Rails < 5.x inside whilst the remainder was identical to the section for Rails 6.x.

Similarly, it was confusing to make reference to Step 4 inside Step 3 for no good reason.