### PR TITLE
Don't unmount components on Turbolinks navigation

### DIFF
--- a/react_ujs/src/events/turbolinks.js
+++ b/react_ujs/src/events/turbolinks.js
@@ -2,11 +2,9 @@ module.exports = {
   // Turbolinks 5+ got rid of named events (?!)
   setup: function(ujs) {
   	ujs.handleEvent('turbolinks:load', ujs.handleMount);
-    ujs.handleEvent('turbolinks:before-render', ujs.handleUnmount);
   },
 
   teardown: function(ujs) {
   	ujs.removeEvent('turbolinks:load', ujs.handleMount);
-    ujs.removeEvent('turbolinks:before-render', ujs.handleUnmount);
   },
 }


### PR DESCRIPTION
[As discussed in #1028](https://github.com/reactjs/react-rails/issues/1028#issuecomment-862475500), unmounting components on `turbolinks:before-render` prevents Turbolinks from restoring the scroll position when navigating back to pages with tall React components. This happens because Turbolinks tries to restore the scroll position before firing the `turbolinks:load` event. Since components were unmounted prior to this, the page might be much shorter than it will be after mounting components causing scroll position restoration to fail.

We've been running this in production for a week now and haven't noticed any issues caused by not unmounting components.