### PR TITLE
Prevent react_ujs from depending on itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,5 @@
   },
   "devDependencies": {
     "webpack": "^2.3.3"
-  },
-  "dependencies": {
-    "react_ujs": "^2.6.1"
   }
 }


### PR DESCRIPTION
### Summary

Doesn't make any sense for a package to depend on itself.

If you import react_ujs manually from npm, the package-lock entry for it looks like
```
"react_ujs": {
      "version": "2.6.2",
      "resolved": "https://registry.npmjs.org/react_ujs/-/react_ujs-2.6.2.tgz",
      "integrity": "sha512-4WH91hVZp0533LsTjbcd9uI9xS/7/e4QkFbDpDjy8Pr7GuUt1gE+cM0zml7Ii9aSUDl2A/zzkUrLN5X9akmViQ==",
      "requires": {
        "react_ujs": "^2.6.1"
      }
    }
```
