### PR TITLE
:memo: Fix VERSIONS.md formatting

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,7 +7,7 @@ You can control what version of React.js (and JSXTransformer) is used by `react-
 
 ## Bundled Versions
 
-| Gem      | React.js |
+| Gem      | React.js |                |
 | -------- | -------- | -------------- |
 | master   | 16.14.0  |
 | 2.6.2    | 16.14.0  |


### PR DESCRIPTION
:memo: Fix VERSIONS.md formatting
[ci skip]

### Summary
A missing pipe in the table header was causing the table to render incorrectly.

### Other Information
N/A
