### PR TITLE
Update webpacker.yml in react:install generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Deprecation
 
 #### Bug Fixes
+- Fix installation crash caused by absolute path for `source_entry_path` in default `config/webpacker.yml` coming from `shakapacker` version 6.x - #1216
 
 ## 2.6.2
 

--- a/lib/generators/react/install_generator.rb
+++ b/lib/generators/react/install_generator.rb
@@ -16,6 +16,19 @@ module React
         default: false,
         desc: "Don't generate server_rendering.js or config/initializers/react_server_rendering.rb"
 
+      # For Shakapacker below version 7, we need to set relative path for source_entry_path
+      def modify_webpacker_yml
+        if webpacker?
+          webpacker_yml_path = 'config/webpacker.yml'
+          gsub_file(
+            webpacker_yml_path,
+            "source_entry_path: /\n",
+            "source_entry_path: packs\n"
+          )
+          reloaded_webpacker_config
+        end
+      end
+
       # Make an empty `components/` directory in the right place:
       def create_directory
         components_dir = if webpacker?
@@ -118,6 +131,11 @@ JS
         else
           Webpacker::Configuration.source_path.join(Webpacker::Configuration.entry_path) # Webpacker <3
         end
+      end
+
+      def reloaded_webpacker_config
+        Webpacker.instance.instance_variable_set(:@config, nil)
+        Webpacker.config
       end
     end
   end

--- a/lib/generators/react/install_generator.rb
+++ b/lib/generators/react/install_generator.rb
@@ -18,8 +18,8 @@ module React
 
       # For Shakapacker below version 7, we need to set relative path for source_entry_path
       def modify_webpacker_yml
-        if webpacker?
-          webpacker_yml_path = 'config/webpacker.yml'
+        webpacker_yml_path = 'config/webpacker.yml'
+        if webpacker? && Pathname.new(webpacker_yml_path).exist?
           gsub_file(
             webpacker_yml_path,
             "source_entry_path: /\n",


### PR DESCRIPTION
### Summary

The default `config/webpacker.yml` on `shakapacker` version 6.x is set to absolute path of `/` which points to root of the filesystem. This breaks installation process of react-rails.

This commit is a workaround for Shakapacker 6.x. Version 7 is expected to resolve this issue.

Related issues:
- [Upgrade docs to refer to Shakapacker](https://github.com/reactjs/react-rails/issues/1211)
- [Absolute source_entry_path in webpacker.yml refers to filesystem root](https://github.com/shakacode/shakapacker/pull/205)