### PR TITLE
Add support for multiple `require.context` with addition of `useContexts` (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### New Features
 - Camelizes keys with primitive values, in addition to hashes #946
 - Expose alternative implementations for `ReactUJS.getConstructor` #1050
+- Add support for multiple `require.context` with addition of `useContexts` #1221
 - Update dependencies
   - react to 17.0.2 #1218
   - webpack to 5.74.0

--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ In some cases, having multiple `require.context` may be desired - for example, i
 
 ```js
 // server_rendering.js
-var componentsRequireContext = require.context('components', true);
+var applicationRequireContext = require.context('application', true);
 var searchRequireContext = require.context('search', true);
 var checkoutRequireContext = require.context('checkout', true);
 
 var ReactRailsUJS = require('react_ujs');
 ReactRailsUJS.useContexts([
-  componentsRequireContext,
+  applicationRequireContext,
   searchRequireContext,
   checkoutRequireContext
 ]);

--- a/README.md
+++ b/README.md
@@ -172,17 +172,17 @@ ReactRailsUJS.useContext(myCustomContext)
 
 If `require` fails to find your component, [`ReactRailsUJS`](#ujs) falls back to the global namespace, described in [Use with Asset Pipeline](#use-with-asset-pipeline).
 
-In some cases, having multiple `require.context` may be desired - for example, if you have additional entry points to create JavaScript files for different routes, you would add multiple `require.context` to your `server_rendering.js` to allow for [Server-Side Rendering](#server-side-rendering) across your application. If so, an array of `require.context` can be passed to `ReactRailsUJS.useContexts`. With an array of contexts, an attempt will be made to `require` the component from each context before falling back to the global namespace as described above.
+In some cases, having multiple `require.context` entries may be desired. In a larger application, you might find it helpful to split your JavaScript by routes/controllers to avoid serving unused components and improve your site performance by keeping bundles smaller. For example, you might have separate bundles for homepage, search, and checkout routes. In that scenario, you can add an array of `require.context` component directory paths via `useContexts` to `server_rendering.js`, to allow for [Server-Side Rendering](#server-side-rendering) across your application
 
 ```js
 // server_rendering.js
-var applicationRequireContext = require.context('application', true);
+var homepageRequireContext = require.context('homepage', true);
 var searchRequireContext = require.context('search', true);
 var checkoutRequireContext = require.context('checkout', true);
 
 var ReactRailsUJS = require('react_ujs');
 ReactRailsUJS.useContexts([
-  applicationRequireContext,
+  homepageRequireContext,
   searchRequireContext,
   checkoutRequireContext
 ]);

--- a/README.md
+++ b/README.md
@@ -172,6 +172,22 @@ ReactRailsUJS.useContext(myCustomContext)
 
 If `require` fails to find your component, [`ReactRailsUJS`](#ujs) falls back to the global namespace, described in [Use with Asset Pipeline](#use-with-asset-pipeline).
 
+In some cases, having multiple `require.context` may be desired - for example, if you have additional entry points to create JavaScript files for different routes, you would add multiple `require.context` to your `server_rendering.js` to allow for [Server-Side Rendering](#server-side-rendering) across your application. If so, an array of `require.context` can be passed to `ReactRailsUJS.useContexts`. With an array of contexts, an attempt will be made to `require` the component from each context before falling back to the global namespace as described above.
+
+```js
+// server_rendering.js
+var componentsRequireContext = require.context('components', true);
+var searchRequireContext = require.context('search', true);
+var checkoutRequireContext = require.context('checkout', true);
+
+var ReactRailsUJS = require('react_ujs');
+ReactRailsUJS.useContexts([
+  componentsRequireContext,
+  searchRequireContext,
+  checkoutRequireContext
+]);
+```
+
 ### File naming
 
 React-Rails supports plenty of file extensions such as: .js, .jsx.js, .js.jsx, .es6.js, .coffee, etcetera!

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -6,6 +6,7 @@ var detectEvents = require("./src/events/detect")
 var constructorFromGlobal = require("./src/getConstructor/fromGlobal")
 var constructorFromRequireContext = require("./src/getConstructor/fromRequireContext")
 var constructorFromRequireContextWithGlobalFallback = require("./src/getConstructor/fromRequireContextWithGlobalFallback")
+var constructorFromRequireContextsWithGlobalFallback = require("./src/getConstructor/fromRequireContextsWithGlobalFallback")
 const { supportsHydration, reactHydrate, createReactRootLike } = require("./src/renderHelpers")
 
 var ReactRailsUJS = {
@@ -77,6 +78,13 @@ var ReactRailsUJS = {
   // then falling back to global lookup.
   useContext: function(requireContext) {
     this.getConstructor = constructorFromRequireContextWithGlobalFallback(requireContext)
+  },
+
+  // Given an array of Webpack `require.context`,
+  // try finding components with `require`,
+  // then falling back to global lookup.
+  useContexts: function(requireContexts) {
+    this.getConstructor = constructorFromRequireContextsWithGlobalFallback(requireContexts)
   },
 
   // Render `componentName` with `props` to a string,

--- a/react_ujs/src/getConstructor/fromRequireContextsWithGlobalFallback.js
+++ b/react_ujs/src/getConstructor/fromRequireContextsWithGlobalFallback.js
@@ -1,0 +1,41 @@
+// Make a function which:
+// - First tries to require the name
+// - Then falls back to global lookup
+var fromGlobal = require("./fromGlobal");
+var fromRequireContext = require("./fromRequireContext");
+
+module.exports = function (reqctxs) {
+  var fromCtxs = reqctxs.map((reqctx) => fromRequireContext(reqctx));
+  return function (className) {
+    var component;
+    try {
+      var index = 0,
+        fromCtx,
+        firstErr;
+      do {
+        fromCtx = fromCtxs[index];
+
+        try {
+          // `require` will raise an error if this className isn't found:
+          component = fromCtx(className);
+        } catch (fromCtxErr) {
+          if (!firstErr) {
+            firstErr = fromCtxErr;
+          }
+        }
+
+        index += 1;
+      } while (index < fromCtxs.length);
+      if (!component) throw firstErr;
+    } catch (firstErr) {
+      // fallback to global:
+      try {
+        component = fromGlobal(className);
+      } catch (secondErr) {
+        console.error(firstErr);
+        console.error(secondErr);
+      }
+    }
+    return component;
+  };
+};


### PR DESCRIPTION
### Summary

In some cases, it is desirable to have multiple `require.context` entries and attempt to resolve in each before falling back to global. This PR adds `useContexts` (in the pattern of `useContext`) which accepts an array of `require.context` and attempts to resolve the component/module in each context before falling back to global.

In a larger application, you might find it helpful to split your JavaScript by routes/controllers to avoid serving unused components and improve your site performance by keeping bundles smaller. For example, you might have separate bundles for homepage, search, and checkout routes. In that scenario, you can add multiple `require.context` component directory paths via `useContexts` to `server_rendering.js`, so that you can server side render across all of your routes.

```js
// server_rendering.js
var homepageRequireContext = require.context('homepage', true);
var searchRequireContext = require.context('search', true);
var checkoutRequireContext = require.context('checkout', true);

var ReactRailsUJS = require('react_ujs');
ReactRailsUJS.useContexts([
  homepageRequireContext,
  searchRequireContext,
  checkoutRequireContext
]);
```

### Other Information

This code change was originally authored by @cymen in https://github.com/reactjs/react-rails/pull/1144. I have added additional documentation and brought it up to date with master to help get it released.