### PR TITLE
Switch ReactDOM to ESM import to match ESM exports

### DIFF
--- a/react_ujs/src/renderHelpers.js
+++ b/react_ujs/src/renderHelpers.js
@@ -1,4 +1,4 @@
-const ReactDOM = require("react-dom")
+import ReactDOM from "react-dom"
 
 export function supportsHydration() {
   return typeof ReactDOM.hydrate === "function" || typeof ReactDOM.hydrateRoot === "function"


### PR DESCRIPTION
### Summary

We are experiencing a breaking change when using react_ujs@2.6.2 (2.6.1 worked fine) when built into a Vite project. ReactDOM is not defined when attempting to import it in `renderHelpers.js`. Through changing the code in node_modules for react_ujs, we have found that changing ReactDOM to an ESM import resolves the issue. This is because build tools often (I recall having this issue in the past with Webpack) have trouble mixing requires (non-ESM) with ESM exports. This PR resolves this issue by changing to an import.

### Alternatives

The other option, to make this code consistent with the rest of this project, would be to switch the named exports to a `module.exports` object. If that is preferred, I can update this PR.