### PR TITLE
replace nulls in props from Rails with undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ If you need help upgrading `react-rails`, `webpacker` to `shakapacker`, or JS pa
 Changes since last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
+- Add option to replace `null`s in props with `undefined` via `ReactRailsUJS.setOptions` #1273
 
 ### Breaking Changes
 - Remove support & testing for Webpacker 3/4.

--- a/README.md
+++ b/README.md
@@ -528,6 +528,19 @@ use it like so:
 ReactUJS.getConstructor = ReactUJS.constructorFromRequireContext(require.context('components', true));
 ```
 
+### Configure UJS
+
+You can change the behaviours of `ReactRailsUJS` by calling `setOptions(options)` function:
+
+```js
+ReactRailsUJS.setOptions({ replaceNull: false });
+```
+
+Current acceptable options are the following:
+
+| Key | Value type | Description | Default |
+| --- | ---------- | ----------- | ------- |
+| `replaceNull` | boolean (`true` / `false`) | Whether to replace all `null`s in the props from Rails (originally `nil` in Rails) with `undefined`. May be helpful when defining the types of the props in TypeScript. See [discussion#1272](https://github.com/reactjs/react-rails/discussions/1272). | `false`|
 
 ## Server-Side Rendering
 

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -8,6 +8,7 @@ var constructorFromRequireContext = require("./src/getConstructor/fromRequireCon
 var constructorFromRequireContextWithGlobalFallback = require("./src/getConstructor/fromRequireContextWithGlobalFallback")
 var constructorFromRequireContextsWithGlobalFallback = require("./src/getConstructor/fromRequireContextsWithGlobalFallback")
 const { supportsHydration, reactHydrate, createReactRootLike } = require("./src/renderHelpers")
+const { replaceNullWithUndefined } = require("./src/options")
 
 var ReactRailsUJS = {
   // This attribute holds the name of component which should be mounted
@@ -30,6 +31,11 @@ var ReactRailsUJS = {
   jQuery: (typeof window !== 'undefined') && (typeof window.jQuery !== 'undefined') && window.jQuery,
 
   components: {},
+
+  // Set default values for options.
+  options: {
+    replaceNull: false,
+  },
 
   // helper method for the mount and unmount methods to find the
   // `data-react-class` DOM elements
@@ -106,7 +112,8 @@ var ReactRailsUJS = {
       var className = node.getAttribute(ujs.CLASS_NAME_ATTR);
       var constructor = ujs.getConstructor(className);
       var propsJson = node.getAttribute(ujs.PROPS_ATTR);
-      var props = propsJson && JSON.parse(propsJson);
+      var props = propsJson && (ujs.options.replaceNull ? replaceNullWithUndefined(JSON.parse(propsJson))
+                                                        : JSON.parse(propsJson));
       var hydrate = node.getAttribute(ujs.RENDER_ATTR);
       var cacheId = node.getAttribute(ujs.CACHE_ID_ATTR);
       var turbolinksPermanent = node.hasAttribute(ujs.TURBOLINKS_PERMANENT_ATTR);

--- a/react_ujs/index.js
+++ b/react_ujs/index.js
@@ -8,7 +8,7 @@ var constructorFromRequireContext = require("./src/getConstructor/fromRequireCon
 var constructorFromRequireContextWithGlobalFallback = require("./src/getConstructor/fromRequireContextWithGlobalFallback")
 var constructorFromRequireContextsWithGlobalFallback = require("./src/getConstructor/fromRequireContextsWithGlobalFallback")
 const { supportsHydration, reactHydrate, createReactRootLike } = require("./src/renderHelpers")
-const { replaceNullWithUndefined } = require("./src/options")
+const { replaceNullWithUndefined, overwriteOption } = require("./src/options")
 
 var ReactRailsUJS = {
   // This attribute holds the name of component which should be mounted
@@ -35,6 +35,10 @@ var ReactRailsUJS = {
   // Set default values for options.
   options: {
     replaceNull: false,
+  },
+
+  setOptions: function(newOptions) {
+    overwriteOption(ReactRailsUJS.options, newOptions, "replaceNull")
   },
 
   // helper method for the mount and unmount methods to find the

--- a/react_ujs/src/options.js
+++ b/react_ujs/src/options.js
@@ -1,0 +1,13 @@
+export function replaceNullWithUndefined(obj) {
+  Object.entries(obj).forEach((entry) => {
+    const key = entry[0]
+    const value = entry[1]
+    if(!!value && typeof value === 'object') {
+      return replaceNullWithUndefined(value)
+    }
+    if (value === null) {
+      obj[key] = undefined
+    }
+  })
+  return obj
+}

--- a/react_ujs/src/options.js
+++ b/react_ujs/src/options.js
@@ -11,3 +11,8 @@ export function replaceNullWithUndefined(obj) {
   })
   return obj
 }
+
+export function overwriteOption(ujsOptions, newOptions, key) {
+  if (!Object.prototype.hasOwnProperty.call(newOptions, key)) return
+  ujsOptions[key] = newOptions[key]
+}


### PR DESCRIPTION
### Summary

closes: discussion #1272 

I'm currently working a Rails+React project and eliminating `null`s from the type definitions in the frontend as possible, since my team members and I have been bothered about differentiation between `null` and `undefined` in terms of typing.

This PR adds an opt-in option to make react_ujs replace all `null`s in the props from Rails with `undefined`s, alongside the option system to allow to selectively enable each option. I've made the option default to `false` so that all existing projects won't break.

Read the [discussion](https://github.com/reactjs/react-rails/discussions/1272) for the more detailed background.

### Other Information

As soon as this gets merged, I'll also update [@types/react_ujs](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react_ujs) to add type definitions of `setOptions(option)`

### Pull Request checklist
<!--_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._-->

- [ ] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file
