### PR TITLE
Update docs to cover sp7 - for react-rails v2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ $ cd my-app
 ```
 
 2. Install `shakapacker`:
+We recommend to use the latest version of Shakapacker. For that, you need to install version 6 and after running install generator of react-rails, upgrade the project to Shakapacker 7.
+
 ```bash
-$ bundle add shakapacker --strict
+$ bundle add shakapacker --version 6.6.0 --strict
 $ rails webpacker:install
 ```
 
@@ -128,6 +130,8 @@ This gives you:
 - `app/javascript/components/` directory for your React components
 - [`ReactRailsUJS`](#ujs) setup in `app/javascript/packs/application.js`
 - `app/javascript/packs/server_rendering.js` for [server-side rendering](#server-side-rendering)
+
+After this step you can upgrade your Shakpacker to version 7. For this, check Shakapacker [v7 upgrade](https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md) guide. 
 
 5. Generate your first component:
 ```bash

--- a/README.md
+++ b/README.md
@@ -94,10 +94,8 @@ $ cd my-app
 ```
 
 2. Install `shakapacker`:
-We recommend to use the latest version of Shakapacker. For that, you need to install version 6 and after running install generator of react-rails, upgrade the project to Shakapacker 7.
-
 ```bash
-$ bundle add shakapacker --version 6.6.0 --strict
+$ bundle add shakapacker --strict
 $ rails webpacker:install
 ```
 
@@ -130,8 +128,6 @@ This gives you:
 - `app/javascript/components/` directory for your React components
 - [`ReactRailsUJS`](#ujs) setup in `app/javascript/packs/application.js`
 - `app/javascript/packs/server_rendering.js` for [server-side rendering](#server-side-rendering)
-
-After this step you can upgrade your Shakpacker to version 7. For this, check Shakapacker [v7 upgrade](https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md) guide. 
 
 5. Generate your first component:
 ```bash

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ cd my-app
 2. Install `shakapacker`:
 ```bash
 $ bundle add shakapacker --strict
-$ rails webpacker:install
+$ rails shakapacker:install # or `rails webpacker:install` for Shakapacker v6
 ```
 
 3. Install `react` and some other required npm packages:
@@ -166,7 +166,7 @@ Output: greeting: Hello from react-rails", inspect webpage in your browser to se
 In order to run dev server with HMR feature you need to parallely run:
 
 ```bash
-$ ./bin/webpacker-dev-server
+$ ./bin/shakapacker-dev-server # or ./bin/webpacker-dev-server for Shakapacker 6
 ```
 
 Note: On Rails 6 you need to specify `webpack-dev-server` host. To this end, update `config/initializers/content_security_policy.rb` and uncomment relevant lines.


### PR DESCRIPTION
### Summary

This PR updates documentation for **version 2.7** to cover Shakapacker 7.

Notice: this is for version 2.7 branch. For version 3 we need more updates.

