### PR TITLE
Include PR as a trigger for CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,9 @@
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
 name: Ruby
-on: [push]
+
+on: [push, pull_request]
+
 jobs:
   check_react_and_ujs:
     strategy:


### PR DESCRIPTION
To run CI on PR made by contributors other than the official team, we need to include pull_request in the list of triggers.
