### PR TITLE
Update lock files in tests for version 3

### DIFF
--- a/gemfiles/base.gemfile.lock
+++ b/gemfiles/base.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    react-rails (2.7.1)
+    react-rails (3.0.0)
       babel-transpiler (>= 0.7.0)
       connection_pool
       execjs
@@ -169,10 +169,6 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.14.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
-      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -238,10 +234,6 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -271,7 +263,6 @@ DEPENDENCIES
   react-rails!
   selenium-webdriver
   test-unit (~> 2.5)
-  webdrivers
 
 BUNDLED WITH
    2.4.9

--- a/gemfiles/shakapacker.gemfile.lock
+++ b/gemfiles/shakapacker.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    react-rails (2.7.1)
+    react-rails (3.0.0)
       babel-transpiler (>= 0.7.0)
       connection_pool
       execjs
@@ -244,10 +244,6 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -278,7 +274,6 @@ DEPENDENCIES
   selenium-webdriver
   shakapacker (= 7.0.2)
   test-unit (~> 2.5)
-  webdrivers
 
 BUNDLED WITH
    2.4.9

--- a/gemfiles/sprockets_3.gemfile.lock
+++ b/gemfiles/sprockets_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    react-rails (2.7.1)
+    react-rails (3.0.0)
       babel-transpiler (>= 0.7.0)
       connection_pool
       execjs
@@ -246,10 +246,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webdrivers (4.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -282,7 +278,6 @@ DEPENDENCIES
   sprockets-rails
   test-unit (~> 2.5)
   turbolinks (~> 5)
-  webdrivers
 
 BUNDLED WITH
    2.4.9

--- a/gemfiles/sprockets_4.gemfile.lock
+++ b/gemfiles/sprockets_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    react-rails (2.7.1)
+    react-rails (3.0.0)
       babel-transpiler (>= 0.7.0)
       connection_pool
       execjs
@@ -246,10 +246,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webdrivers (4.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -282,7 +278,6 @@ DEPENDENCIES
   sprockets-rails
   test-unit (~> 2.5)
   turbolinks (~> 5)
-  webdrivers
 
 BUNDLED WITH
    2.4.9


### PR DESCRIPTION
Update `Gemfile.lock` of tests to match version 3.

@Judahmeek 
Need to merge this to keep #1293 cleaner.