### PR TITLE
chore: remove extra space

### DIFF
--- a/test/react/rails/react_rails_ujs_test.rb
+++ b/test/react/rails/react_rails_ujs_test.rb
@@ -141,7 +141,7 @@ class ReactRailsUJSTest < ActionDispatch::IntegrationTest
       assert_greeting(page, "Hello Bob")
     end
 
-    test "react_ujs does not unmount components that do not match a selector reference for the component" do  # rubocop:disable Minitest/MultipleAssertions
+    test "react_ujs does not unmount components that do not match a selector reference for the component" do # rubocop:disable Minitest/MultipleAssertions
       visit "/pages/1"
 
       assert_greeting page, "Hello Bob"


### PR DESCRIPTION
### Summary

This is being failed by rubocop but not actually enforced due to the workflow not running on pull requests.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
