### PR TITLE
ci: run `rubocop` on pull requests

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,6 @@
 name: Rubocop
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   rubocop:


### PR DESCRIPTION
### Summary

Currently rubocop failures are not properly coming through on pull requests because the workflow only runs on push - this is why e.g. #1320 was able to slip through

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
