### PR TITLE
chore: switch default branch to `main`

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,7 @@ name: Rubocop
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ name: Ruby
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ _Please add entries here for your pull requests that are not yet released. Inclu
 ## [3.0.0] - 2023-08-14
 
 ### Breaking Changes
-- Requires separate compilations for server & client bundles if using Shakapacker (see [Webpack config](https://github.com/reactjs/react-rails/tree/master/test/dummy/config/webpack)) #1274
+- Requires separate compilations for server & client bundles if using Shakapacker (see [Webpack config](https://github.com/reactjs/react-rails/tree/main/test/dummy/config/webpack)) #1274
 - Replaces WebpackManifestContainer, which searched for assets in the webpack manifest, with SeparateServerBundleContainer, which expects a single server bundle file & does not use the webpack manifest at all. #1274
 - Upgrades React-Rails' embedded react to v18.2.0. Uses node polyfill plugin & fast-text-encoder for SSR text encoding. #1290
 - If using Webpacker/Shakapacker, requires upgrading to Shakapacker v7 #1274 and #1285
@@ -573,7 +573,7 @@ _Please add entries here for your pull requests that are not yet released. Inclu
 - Server rendering with `prerender: true`
 - Transform `.jsx` in the asset pipeline
 
-[Unreleased]: https://github.com/reactjs/react-rails/compare/v3.2.0...master
+[Unreleased]: https://github.com/reactjs/react-rails/compare/v3.2.0...main
 [3.2.0]: https://github.com/reactjs/react-rails/compare/v3.1.1...v3.2.0
 [3.1.1]: https://github.com/reactjs/react-rails/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/reactjs/react-rails/compare/v3.0.0...v3.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ With 5 Million+ downloads of the react-rails Gem and another 2 Million+ download
 
 What follows is a set of guidelines for contributing to React-Rails, inside the [react-js Organization](https://github.com/reactjs), part of the wider [React Community](https://reactcommunity.org/)
 
-By contributing to React-Rails, you agree to abide by the [code of conduct](https://github.com/reactjs/react-rails/blob/master/CODE_OF_CONDUCT.md).
+By contributing to React-Rails, you agree to abide by the [code of conduct](https://github.com/reactjs/react-rails/blob/main/CODE_OF_CONDUCT.md).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -36,7 +36,7 @@ By contributing to React-Rails, you agree to abide by the [code of conduct](http
 ### Reporting Bugs
 
 #### Before Submitting A Bug Report
-* **Check the [wiki](https://github.com/reactjs/react-rails/wiki).** You might be able to find a guide on what you're experiencing. Most importantly, check if you can reproduce the problem [in the latest version of React-Rails with React_ujs](https://github.com/reactjs/react-rails/tree/master), sometimes we have already fixed the issue.
+* **Check the [wiki](https://github.com/reactjs/react-rails/wiki).** You might be able to find a guide on what you're experiencing. Most importantly, check if you can reproduce the problem [in the latest version of React-Rails with React_ujs](https://github.com/reactjs/react-rails/tree/main), sometimes we have already fixed the issue.
 * **Perform a [cursory search](https://github.com/reactjs/react-rails/issues)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one. If **the issue is closed** open a new issue with reproduction steps and reference the old one.
 * **If the problem is with pre-rendering, turn off pre-rendering and look at Chrome's developer console**, that normally reveals more details about what the true error message is if it's a syntax error in a component or failing to require a component file.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The Wiki page features a significant amount of additional information about Reac
 
 With 5 Million+ downloads of the react-rails Gem and another 2 Million+ downloads of react_ujs on NPM, you're helping the biggest React + Rails community!
 
-By contributing to React-Rails, you agree to abide by the [code of conduct](https://github.com/reactjs/react-rails/blob/master/CODE_OF_CONDUCT.md).
+By contributing to React-Rails, you agree to abide by the [code of conduct](https://github.com/reactjs/react-rails/blob/main/CODE_OF_CONDUCT.md).
 
 You can always help by submitting patches or triaging issues. Even offering reproduction steps to issues is incredibly helpful!
 
@@ -131,4 +131,4 @@ The following companies support the development of this and other open-source pr
   </picture>
 </a>
 
-Please see our [Contribution guide](https://github.com/reactjs/react-rails/blob/master/CONTRIBUTING.md) for more info.
+Please see our [Contribution guide](https://github.com/reactjs/react-rails/blob/main/CONTRIBUTING.md) for more info.

--- a/docs/component-generator.md
+++ b/docs/component-generator.md
@@ -135,4 +135,4 @@ You can also specify this option in `react_component`:
 
 To make simple changes to Component templates, copy the respective template file to your Rails project at `lib/templates/react/component/template_filename`.
 
-For example, to change the [ES6 Component template](https://github.com/reactjs/react-rails/blob/master/lib/generators/templates/component.es6.jsx), copy it to `lib/templates/react/component/component.es6.jsx` and modify it.
+For example, to change the [ES6 Component template](https://github.com/reactjs/react-rails/blob/main/lib/generators/templates/component.es6.jsx), copy it to `lib/templates/react/component/component.es6.jsx` and modify it.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -331,4 +331,4 @@ MyApp::Application.configure do
 end
 ```
 
-Be sure to restart your Rails server after changing these files. See [VERSIONS.md](https://github.com/reactjs/react-rails/blob/master/VERSIONS.md) to learn which version of React.js is included with your `react-rails` version. In some edge cases you may need to bust the sprockets cache with `rake tmp:clear`
+Be sure to restart your Rails server after changing these files. See [VERSIONS.md](https://github.com/reactjs/react-rails/blob/main/VERSIONS.md) to learn which version of React.js is included with your `react-rails` version. In some edge cases you may need to bust the sprockets cache with `rake tmp:clear`

--- a/docs/migrating-from-react-rails-to-react_on_rails.md
+++ b/docs/migrating-from-react-rails-to-react_on_rails.md
@@ -30,7 +30,7 @@
 
 ## Steps to migrate
 
-In this guide, it is assumed that you have upgraded the `react-rails` project to use `shakapacker` version 7. To this end, check out [Shakapacker v7 upgrade guide](https://github.com/shakacode/shakapacker/tree/master/docs/v7_upgrade.md). Upgrading `react-rails` to version 3 can make the migration smoother but it is not required.
+In this guide, it is assumed that you have upgraded the `react-rails` project to use `shakapacker` version 7. To this end, check out [Shakapacker v7 upgrade guide](https://github.com/shakacode/shakapacker/tree/main/docs/v7_upgrade.md). Upgrading `react-rails` to version 3 can make the migration smoother but it is not required.
 
 1. Update Deps
 

--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -26,7 +26,7 @@ Server rendering is powered by [`ExecJS`](https://github.com/rails/execjs) and s
 
 - `react-rails` must load your code. By convention, it uses `server_rendering.js`, which was created
 by the install task. This file must include your components _and_ their dependencies (eg, Underscore.js).
-- Requires separate compilations for server & client bundles (see [Webpack config](https://github.com/reactjs/react-rails/tree/master/test/dummy/config/webpack))
+- Requires separate compilations for server & client bundles (see [Webpack config](https://github.com/reactjs/react-rails/tree/main/test/dummy/config/webpack))
 - Your code can't reference `document` or `window`. Prerender processes don't have access to `document` or `window`,
 so jQuery and some other libs won't work in this environment :(
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -12,7 +12,7 @@
 ## 2.7 to 3.0
 - Keep your `react_ujs` up to date: `yarn upgrade`
 - **Drop support for Webpacker:** Before any ReactRails upgrade, make sure upgrading from Webpacker to Shakapacker 7. For more information check out Shakapacker  
-- **SSR:** ReactRails 3.x requires separate compilations for server & client bundles. See [Webpack config](https://github.com/reactjs/react-rails/tree/master/test/dummy/config/webpack) directory in the dummy app to addapt the new implementation.
+- **SSR:** ReactRails 3.x requires separate compilations for server & client bundles. See [Webpack config](https://github.com/reactjs/react-rails/tree/main/test/dummy/config/webpack) directory in the dummy app to addapt the new implementation.
 
 ## 2.3 to 2.4
 


### PR DESCRIPTION
### Summary

This is the canonical default branch these days - might as well get the switch over with; once this is merged ideally the `master` branch should be renamed to `main` using GitHub's UI so that workflow runs and other such logs are retained.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [x] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] ~Update CHANGELOG file~
