### PR TITLE
chore: specify `yarn` as package manager and remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,13 @@
   "name": "react_ujs",
   "version": "3.1.1",
   "description": "Rails UJS for the react-rails gem",
+  "repository": "reactjs/react-rails",
   "main": "react_ujs/index.js",
   "files": [
     "react_ujs"
   ],
-  "repository": "reactjs/react-rails",
   "scripts": {
     "build": "cd react_ujs && webpack"
-  },
-  "devDependencies": {
-    "webpack": "^5.74.0",
-    "webpack-cli": "^5.0.1"
   },
   "dependencies": {
     "@babel/preset-react": "^7.22.5",
@@ -24,5 +20,9 @@
     "react-dom": "^18.2.0",
     "react_ujs": "^2.7.1",
     "style-loader": "^3.3.3"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0",
+    "webpack-cli": "^5.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   "devDependencies": {
     "webpack": "^5.74.0",
     "webpack-cli": "^5.0.1"
-  }
+  },
+  "packageManager": "yarn@1.22.21"
 }

--- a/react-builds/package.json
+++ b/react-builds/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Prepares react-rails asset files",
   "main": "react.js",
+  "scripts": {
+    "build": "NODE_ENV=development webpack && NODE_ENV=production webpack"
+  },
   "dependencies": {
     "create-react-class": "^15.6.2",
     "fast-text-encoding": "^1.0.6",
@@ -13,8 +16,5 @@
     "react-dom": "^18.2.0",
     "react-transition-group": "1.1.1",
     "webpack": "^5.74.0"
-  },
-  "scripts": {
-    "build": "NODE_ENV=development webpack && NODE_ENV=production webpack"
   }
 }

--- a/react-builds/package.json
+++ b/react-builds/package.json
@@ -14,7 +14,6 @@
     "prop-types": "^15.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-transition-group": "1.1.1",
     "webpack": "^5.74.0"
   },
   "packageManager": "yarn@1.22.21"

--- a/react-builds/package.json
+++ b/react-builds/package.json
@@ -16,5 +16,6 @@
     "react-dom": "^18.2.0",
     "react-transition-group": "1.1.1",
     "webpack": "^5.74.0"
-  }
+  },
+  "packageManager": "yarn@1.22.21"
 }

--- a/react-builds/yarn.lock
+++ b/react-builds/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.1.2":
-  version "7.22.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.3.tgz#0a7fce51d43adbf0f7b517a71f4c3aaca92ebcbb"
-  integrity sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -400,11 +393,6 @@ caniuse-lite@^1.0.30001489:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz#3e56e04a48da7a79eae994559eb1ec02aaac862f"
   integrity sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==
 
-chain-function@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
-  integrity sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg==
-
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
@@ -513,13 +501,6 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
-
-dom-helpers@^3.2.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
 
 domain-browser@^4.22.0:
   version "4.22.0"
@@ -1057,15 +1038,6 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-transition-group@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.1.1.tgz#f9d0f0dff82f52574fc5ab30684add24948d0f23"
-  integrity sha512-Qhrfon1bzP6rONpSp06Up5gfJdMRSlluqO8x800PtKCJ71kkO57zhBTfGKQdzqQlwi6hQ2kuuuNq+zSsi9mTxw==
-  dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
-    warning "^3.0.0"
-
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -1092,11 +1064,6 @@ readable-stream@^4.0.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
-
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -1292,13 +1259,6 @@ vm-browserify@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==
-  dependencies:
-    loose-envify "^1.0.0"
 
 watchpack@^2.4.0:
   version "2.4.0"

--- a/test/dummy/package.json
+++ b/test/dummy/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "yalc-postinstall": "yalc link react_ujs"
+  },
   "dependencies": {
     "@babel/core": "^7.18.2",
     "@babel/plugin-transform-runtime": "^7.18.2",
@@ -27,12 +30,9 @@
     "webpack-sources": "^3.2.3"
   },
   "devDependencies": {
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "react-refresh": "^0.13.0",
     "webpack-dev-server": "^4.9.2"
-  },
-  "scripts": {
-    "yalc-postinstall": "yalc link react_ujs"
   }
 }


### PR DESCRIPTION
### Summary

With #1306 landed we now support any of the main package managers which includes for our internal plumbing, and since we're not specifying a package manager `npm` is being used by default which is highlighting a peer dependency conflict with `react-transition-group` - it turns out that we don't actually need this package anymore so it can just go, but I've also explicitly set the `packageManager` to be `yarn` since that is what was being used before.

Since this is also touching the `package.json` files, I figured it would be a good time to slip in running `sort-package-json` for consistency.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~
