### PR TITLE
Update get-started.md | Removes deprecation warning for webpackconfig in favor of generateWebpackConfig

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -194,12 +194,16 @@ Then modify the webpack config to use it as a plugin:
 
 ```js
 // config/webpack/webpack.config.js
-const { webpackConfig, merge } = require("shakapacker");
-const ForkTSCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+const { generateWebpackConfig, merge } = require('shakapacker')
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
-module.exports = merge(webpackConfig, {
-  plugins: [new ForkTSCheckerWebpackPlugin()],
-});
+const webpackConfig = generateWebpackConfig()
+
+module.exports = merge(
+  webpackConfig, {
+    plugins: [new ForkTsCheckerWebpackPlugin()]
+  }
+);
 ```
 
 Doing this will allow React-Rails to support the .tsx extension. Additionally, it is recommended to add `ts` and `tsx` to the `server_renderer_extensions` in your application configuration:


### PR DESCRIPTION
### Summary

Using webpackconfig throws a deprecation warning and encourages user to use generateWebpackConfig() instead. Updates docs to avoid this deprecation warning. 

### Other Information

```
Output: 

 $ ./bin/shakapacker-dev-server
⚠️
DEPRECATION NOTICE:
The 'webpackConfig' is deprecated and will be removed in a future version.
Please use 'globalMutableWebpackConfig' instead, or use
'generateWebpackConfig()' to avoid unwanted config mutation across the app.

For more information, see version 7 upgrade documentation at:
https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md
```

### Pull Request checklist

- [x ] Add/update test to cover these changes
- [ x] Update documentation
- [ x] Update CHANGELOG file
