### PR TITLE
Add honeybadger logo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The following companies provide licenses to the ShakaCode team, supporting the d
 </a>
 <a href="https://www.honeybadger.io/">
   <picture>
-    <img alt="Control Plane" src="https://user-images.githubusercontent.com/4244251/184881133-79ee9c3c-8165-4852-958e-31687b9536f4.png" height="70px">
+    <img alt="HoneyBadger" src="https://user-images.githubusercontent.com/4244251/184881133-79ee9c3c-8165-4852-958e-31687b9536f4.png" height="70px">
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ The following companies provide licenses to the ShakaCode team, supporting the d
     <img alt="BrowserStack" src="https://user-images.githubusercontent.com/4244251/184881129-e1edf4b7-3ae1-4ea8-9e6d-3595cf01609e.png" height="55px">
   </picture>
 </a>
+<a href="https://www.honeybadger.io/">
+  <picture>
+    <img alt="Control Plane" src="https://user-images.githubusercontent.com/4244251/184881133-79ee9c3c-8165-4852-958e-31687b9536f4.png" height="70px">
+  </picture>
+</a>
 
 ---
 


### PR DESCRIPTION
### Summary

Add HoneyBadger Logo to the list of supporters in README.
