### PR TITLE
Add package_json Gem requirement into migration doc

### DIFF
--- a/docs/migrating-from-react-rails-to-react_on_rails.md
+++ b/docs/migrating-from-react-rails-to-react_on_rails.md
@@ -35,8 +35,9 @@ In this guide, it is assumed that you have upgraded the `react-rails` project to
 1. Update Deps
 
    1. Replace `react-rails` in `Gemfile` with the latest version of `react_on_rails` and run `bundle install`.
-   2. Remove `react_ujs` from `package.json` and run `yarn install`.
-   3. Commit changes!
+   2. Add `package_json` in `Gemfile` ( if you don't have it already ) and run `bundle install` 
+   3. Remove `react_ujs` from `package.json` and run `yarn install`.
+   4. Commit changes!
 
 2. Run `rails g react_on_rails:install` but do not commit the change. `react_on_rails` installs node dependencies and also creates sample react component, Rails view/controller, and update `config/routes.rb`.
 


### PR DESCRIPTION
### Summary

`package_json` is a required gem for react_on_rails, if you don't have it in your Gemfile you will face the following error:

`/Users/your_user/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in require': cannot load such file -- package_json (LoadError)`

### Other Information

N/A

### Pull Request checklist
- [ ] Add/update test to cover these changes
- [X] Update documentation
- [ ] Update CHANGELOG file
