### PR TITLE
chore: switch default branch to main

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,7 @@ name: Rubocop
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ name: Ruby
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ With 5 Million+ downloads of the react-rails Gem and another 2 Million+ download
 
 What follows is a set of guidelines for contributing to React-Rails, inside the [react-js Organization](https://github.com/reactjs), part of the wider [React Community](https://reactcommunity.org/)
 
-By contributing to React-Rails, you agree to abide by the [code of conduct](https://github.com/reactjs/react-rails/blob/master/CODE_OF_CONDUCT.md).
+By contributing to React-Rails, you agree to abide by the [code of conduct](https://github.com/reactjs/react-rails/blob/main/CODE_OF_CONDUCT.md).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -36,7 +36,7 @@ By contributing to React-Rails, you agree to abide by the [code of conduct](http
 ### Reporting Bugs
 
 #### Before Submitting A Bug Report
-* **Check the [wiki](https://github.com/reactjs/react-rails/wiki).** You might be able to find a guide on what you're experiencing. Most importantly, check if you can reproduce the problem [in the latest version of React-Rails with React_ujs](https://github.com/reactjs/react-rails/tree/master), sometimes we have already fixed the issue.
+* **Check the [wiki](https://github.com/reactjs/react-rails/wiki).** You might be able to find a guide on what you're experiencing. Most importantly, check if you can reproduce the problem [in the latest version of React-Rails with React_ujs](https://github.com/reactjs/react-rails/tree/main), sometimes we have already fixed the issue.
 * **Perform a [cursory search](https://github.com/reactjs/react-rails/issues)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one. If **the issue is closed** open a new issue with reproduction steps and reference the old one.
 * **If the problem is with pre-rendering, turn off pre-rendering and look at Chrome's developer console**, that normally reveals more details about what the true error message is if it's a syntax error in a component or failing to require a component file.
 

--- a/README.md
+++ b/README.md
@@ -102,13 +102,7 @@ The Wiki page features a significant amount of additional information about Reac
 
 ## Contributing
 
-🎉 Thanks for taking the time to contribute! 🎉
-
-With 5 Million+ downloads of the react-rails Gem and another 2 Million+ downloads of react_ujs on NPM, you're helping the biggest React + Rails community!
-
-By contributing to React-Rails, you agree to abide by the [code of conduct](https://github.com/reactjs/react-rails/blob/master/CODE_OF_CONDUCT.md).
-
-You can always help by submitting patches or triaging issues. Even offering reproduction steps to issues is incredibly helpful!
+🎉 Thanks for taking the time to contribute! 🎉 See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details.
 
 # Supporters
 
@@ -156,4 +150,3 @@ The following companies provide licenses to the ShakaCode team, supporting the d
 ---
 
 ShakaCode is [hiring](https://jobs.lever.co/shakacode/3bdbfdb3-4495-4611-a279-01dddddb351abe)!
-Please see our [Contribution guide](https://github.com/reactjs/react-rails/blob/master/CONTRIBUTING.md) for more info.

--- a/docs/component-generator.md
+++ b/docs/component-generator.md
@@ -135,4 +135,4 @@ You can also specify this option in `react_component`:
 
 To make simple changes to Component templates, copy the respective template file to your Rails project at `lib/templates/react/component/template_filename`.
 
-For example, to change the [ES6 Component template](https://github.com/reactjs/react-rails/blob/master/lib/generators/templates/component.es6.jsx), copy it to `lib/templates/react/component/component.es6.jsx` and modify it.
+For example, to change the [ES6 Component template](https://github.com/reactjs/react-rails/blob/main/lib/generators/templates/component.es6.jsx), copy it to `lib/templates/react/component/component.es6.jsx` and modify it.

--- a/docs/migrating-from-react-rails-to-react_on_rails.md
+++ b/docs/migrating-from-react-rails-to-react_on_rails.md
@@ -30,7 +30,7 @@
 
 ## Steps to migrate
 
-In this guide, it is assumed that you have upgraded the `react-rails` project to use `shakapacker` version 7. To this end, check out [Shakapacker v7 upgrade guide](https://github.com/shakacode/shakapacker/tree/master/docs/v7_upgrade.md). Upgrading `react-rails` to version 3 can make the migration smoother but it is not required.
+In this guide, it is assumed that you have upgraded the `react-rails` project to use `shakapacker` version 7. To this end, check out [Shakapacker v7 upgrade guide](https://github.com/shakacode/shakapacker/tree/main/docs/v7_upgrade.md). Upgrading `react-rails` to version 3 can make the migration smoother but it is not required.
 
 1. Update Deps
 

--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -26,7 +26,7 @@ Server rendering is powered by [`ExecJS`](https://github.com/rails/execjs) and s
 
 - `react-rails` must load your code. By convention, it uses `server_rendering.js`, which was created
 by the install task. This file must include your components _and_ their dependencies (eg, Underscore.js).
-- Requires separate compilations for server & client bundles (see [Webpack config](https://github.com/reactjs/react-rails/tree/master/test/dummy/config/webpack))
+- Requires separate compilations for server & client bundles (see [Webpack config](https://github.com/reactjs/react-rails/tree/main/test/dummy/config/webpack))
 - Your code can't reference `document` or `window`. Prerender processes don't have access to `document` or `window`,
 so jQuery and some other libs won't work in this environment :(
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -12,7 +12,7 @@
 ## 2.7 to 3.0
 - Keep your `react_ujs` up to date: `yarn upgrade`
 - **Drop support for Webpacker:** Before any ReactRails upgrade, make sure upgrading from Webpacker to Shakapacker 7. For more information check out Shakapacker  
-- **SSR:** ReactRails 3.x requires separate compilations for server & client bundles. See [Webpack config](https://github.com/reactjs/react-rails/tree/master/test/dummy/config/webpack) directory in the dummy app to addapt the new implementation.
+- **SSR:** ReactRails 3.x requires separate compilations for server & client bundles. See [Webpack config](https://github.com/reactjs/react-rails/tree/main/test/dummy/config/webpack) directory in the dummy app to addapt the new implementation.
 
 ## 2.3 to 2.4
 


### PR DESCRIPTION
### Summary

This PR updates the default branch from `master` to `main` across the codebase. Changes include updating GitHub workflow configurations and all documentation links to reference the new `main` branch.

### Pull Request checklist

- [x] Update documentation