### PR TITLE
Prepare 3.3.0 release and update master to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released. Include LINKS for PRs and committers._
 
+## [3.3.0] - 2024-11-22
+
+#### Added
 - Support for Propshaft server rendering. [PR 1345](https://github.com/reactjs/react-rails/pull/1345) by [elektronaut](https://github.com/elektronaut)
 
 ## [3.2.1] - 2024-05-16
@@ -590,8 +593,9 @@ _Please add entries here for your pull requests that have not yet been released.
 - Server rendering with `prerender: true`
 - Transform `.jsx` in the asset pipeline
 
-[Unreleased]: https://github.com/reactjs/react-rails/compare/v3.2.1...main
-[3.2.1]: https://github.com/reactjs/react-rails/compare/v3.2.1...v3.2.1
+[Unreleased]: https://github.com/reactjs/react-rails/compare/v3.3.0...main
+[3.3.0]: https://github.com/reactjs/react-rails/compare/v3.2.1...v3.3.0
+[3.2.1]: https://github.com/reactjs/react-rails/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/reactjs/react-rails/compare/v3.1.1...v3.2.0
 [3.1.1]: https://github.com/reactjs/react-rails/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/reactjs/react-rails/compare/v3.0.0...v3.1.0

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ React-Rails is a flexible tool to use [React](http://facebook.github.io/react/) 
 
 While ShakaCode will continue to support this gem, you might consider migrating to [React on Rails](https://github.com/shakacode/react_on_rails) or [React on Rails Pro with proper Node rendering](https://www.shakacode.com/react-on-rails-pro/).
 
-Why? React on Rails code receives much more active development and testing. For example, consider the [ReactRailsUJS](https://github.com/reactjs/react-rails/blob/master/react_ujs/index.js) implementation compared to the [ReactOnRails Node package](https://github.com/shakacode/react_on_rails/tree/master/node_package) which is written in TypeScript. For another example, React on Rails has work underway to support the latest React features, such as [React Server Components](https://react.dev/reference/rsc/server-components).
+Why? React on Rails code receives much more active development and testing. For example, consider the [ReactRailsUJS](https://github.com/reactjs/react-rails/blob/main/react_ujs/index.js) implementation compared to the [ReactOnRails Node package](https://github.com/shakacode/react_on_rails/tree/master/node_package) which is written in TypeScript. For another example, React on Rails has work underway to support the latest React features, such as [React Server Components](https://react.dev/reference/rsc/server-components).
 
-You can find [migration to React on Rails steps here](https://github.com/reactjs/react-rails/blob/master/docs/migrating-from-react-rails-to-react_on_rails.md).
+You can find [migration to React on Rails steps here](https://github.com/reactjs/react-rails/blob/main/docs/migrating-from-react-rails-to-react_on_rails.md).
 
 ---
 ## ShakaCode Support

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,7 +9,7 @@ You can control what version of React.js (and JSXTransformer) is used by `react-
 
 | Gem      | React.js |                |
 | -------- | -------- | -------------- |
-| master   | 16.14.0  |
+| main     | 16.14.0  |
 | 2.6.2    | 16.14.0  |
 | 2.6.1    | 16.9.0   |
 | 2.6.0    | 16.8.6   |

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -335,4 +335,4 @@ MyApp::Application.configure do
 end
 ```
 
-Be sure to restart your Rails server after changing these files. See [VERSIONS.md](https://github.com/reactjs/react-rails/blob/master/VERSIONS.md) to learn which version of React.js is included with your `react-rails` version. In some edge cases you may need to bust the sprockets cache with `rake tmp:clear`
+Be sure to restart your Rails server after changing these files. See [VERSIONS.md](https://github.com/reactjs/react-rails/blob/main/VERSIONS.md) to learn which version of React.js is included with your `react-rails` version. In some edge cases you may need to bust the sprockets cache with `rake tmp:clear`


### PR DESCRIPTION
### Summary

Prepares the repository for the 3.3.0 release and updates all internal documentation links from the master branch to the main branch. The 3.3.0 release adds support for Propshaft server rendering.

### Changes

- Updated CHANGELOG.md with 3.3.0 release entry (2024-11-22)
- Updated all internal GitHub links from `/blob/master/` and `/tree/master/` to `/blob/main/` and `/tree/main/`
- Updated VERSIONS.md to reflect main branch instead of master

### Pull Request checklist

- [x] Update documentation
- [x] Update CHANGELOG file
- ~[ ] Add/update test to cover these changes~