### PR TITLE
[codex] Fix Propshaft asset version cache busting

### DIFF
--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -113,6 +113,7 @@ module React
         end
       end
 
+      # :nodoc:
       def self.append_react_build_to_assets_version!(assets, react_build)
         versioned_assets = versioned_assets_for(assets)
         return if versioned_assets.nil?
@@ -130,7 +131,7 @@ module React
       end
 
       def self.versioned_assets?(assets)
-        assets&.respond_to?(:version) && assets.respond_to?(:version=)
+        assets.respond_to?(:version) && assets.respond_to?(:version=)
       end
 
       private_class_method :versioned_assets_for, :versioned_assets?

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -76,10 +76,8 @@ module React
                                                          variant: app.config.react.variant
                                                        })
 
-        sprockets_env = app.assets || app.config.try(:assets) # sprockets-rails 3.x attaches this at a different config
-        unless sprockets_env.nil?
-          sprockets_env.version = [sprockets_env.version, "react-#{asset_variant.react_build}"].compact.join("-")
-        end
+        assets = app.assets || app.config.try(:assets) # sprockets-rails 3.x attaches this at a different config
+        Railtie.append_react_build_to_assets_version!(assets, asset_variant.react_build)
       end
 
       initializer "react_rails.set_variant", after: :engines_blank_point, group: :all do |app|
@@ -114,6 +112,28 @@ module React
           React::JSX::SprocketsStrategy.attach_with_strategy(sprockets_env, app.config.react.sprockets_strategy)
         end
       end
+
+      def self.append_react_build_to_assets_version!(assets, react_build)
+        versioned_assets = versioned_assets_for(assets)
+        return if versioned_assets.nil?
+
+        versioned_assets.version = [versioned_assets.version, "react-#{react_build}"].compact.join("-")
+      end
+
+      def self.versioned_assets_for(assets)
+        return assets if versioned_assets?(assets)
+
+        config = assets.config if assets.respond_to?(:config)
+        return config if versioned_assets?(config)
+
+        nil
+      end
+
+      def self.versioned_assets?(assets)
+        assets&.respond_to?(:version) && assets.respond_to?(:version=)
+      end
+
+      private_class_method :versioned_assets_for, :versioned_assets?
     end
   end
 end

--- a/test/react/rails/railtie_test.rb
+++ b/test/react/rails/railtie_test.rb
@@ -3,11 +3,32 @@
 require "test_helper"
 
 class RailtieTest < ActionDispatch::IntegrationTest
+  VersionedAssets = Struct.new(:version)
+  PropshaftLikeAssembly = Struct.new(:config)
+
   test "reloaders are configured after initializers are loaded" do
     @test_file = File.expand_path("../../dummy/app/pants/yfronts.js", File.dirname(__FILE__))
     FileUtils.touch @test_file
     results = Dummy::Application.reloaders.map(&:updated?)
 
     assert_includes(results, true)
+  end
+
+  test "cache busting updates asset environments with a direct version" do
+    assets = VersionedAssets.new("1.0")
+
+    React::Rails::Railtie.append_react_build_to_assets_version!(assets, "development")
+
+    assert_equal "1.0-react-development", assets.version
+  end
+
+  test "cache busting updates asset assembly configs with a version" do
+    config = ActiveSupport::OrderedOptions.new
+    config.version = "1.0"
+    assembly = PropshaftLikeAssembly.new(config)
+
+    React::Rails::Railtie.append_react_build_to_assets_version!(assembly, "production")
+
+    assert_equal "1.0-react-production", config.version
   end
 end

--- a/test/react/rails/railtie_test.rb
+++ b/test/react/rails/railtie_test.rb
@@ -31,4 +31,18 @@ class RailtieTest < ActionDispatch::IntegrationTest
 
     assert_equal "1.0-react-production", config.version
   end
+
+  test "cache busting is a no-op when assets is nil" do
+    assert_nothing_raised do
+      React::Rails::Railtie.append_react_build_to_assets_version!(nil, "development")
+    end
+  end
+
+  test "cache busting is a no-op when assets has no version" do
+    assets = Object.new
+
+    assert_nothing_raised do
+      React::Rails::Railtie.append_react_build_to_assets_version!(assets, "development")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fix the `react_rails.bust_cache` initializer so it can update the asset version for both Sprockets-style asset environments and Propshaft assemblies.

## Root Cause

`react-rails` treated `app.assets` like a Sprockets environment and wrote `version` directly on it. In Propshaft 1.3.1, `app.assets` is a `Propshaft::Assembly`, and the writable `version` lives on `app.assets.config`, which caused boot to fail with `undefined method 'version'`.

## Changes

- resolve the version-bearing object before appending the React build suffix
- keep the existing Sprockets behavior intact
- add regression tests for both direct `version` objects and Propshaft-style assemblies

## Validation

- `PATH=$HOME/.local/share/mise/installs/ruby/3.2.9/bin:$PATH bundle exec ruby -Itest test/react/rails/railtie_test.rb`
- `PATH=$HOME/.local/share/mise/installs/ruby/3.2.9/bin:$PATH BUNDLE_GEMFILE=gemfiles/propshaft.gemfile bundle exec ruby -Itest test/react/rails/railtie_test.rb`

Fixes #1358
