### PR TITLE
[codex] finish pending Dependabot updates

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -101,7 +101,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: test/dummy/node_modules
-        key: dummy-app-node-modules-cache-${{ hashFiles('test/dummy/yarn.lock') }}
+        key: dummy-app-node-modules-cache-${{ matrix.js_package_manager.name }}-${{ hashFiles('test/dummy/yarn.lock') }}
     - uses: ruby/setup-ruby@v1
       with:
         bundler: 2.4.9
@@ -161,7 +161,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: test/dummy/node_modules
-        key: dummy-app-node-modules-cache-${{ hashFiles('test/dummy/yarn.lock') }}
+        key: dummy-app-node-modules-cache-${{ matrix.js_package_manager.name }}-${{ hashFiles('test/dummy/yarn.lock') }}
     - uses: ruby/setup-ruby@v1
       with:
         bundler: 2.4.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,8 +76,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     appraisal (2.4.1)
       bundler
       rake
@@ -191,7 +191,7 @@ GEM
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (4.0.6)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rack (2.2.22)
     rack-test (2.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       pry (~> 0.10)
     public_suffix (7.0.5)
     racc (1.8.1)
-    rack (2.2.22)
+    rack (2.2.23)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (7.0.5)
+    public_suffix (5.1.1)
     racc (1.8.1)
     rack (2.2.23)
     rack-test (2.0.2)

--- a/test/dummy/yarn.lock
+++ b/test/dummy/yarn.lock
@@ -3788,9 +3788,9 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,9 +1087,9 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.2.3:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pkg-dir@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Supersedes #1413, #1401, #1398, and #1397.

This replacement branch carries the pending Dependabot updates on top of current `main`:
- `addressable` `2.8.0` -> `2.9.0`
- `rack` `2.2.22` -> `2.2.23`
- root `picomatch` `2.3.1` -> `2.3.2`
- `test/dummy` `picomatch` `2.3.1` -> `2.3.2`

One manual correction is included: the raw Dependabot `addressable` lockfile resolved `public_suffix` to `7.0.5`, but `public_suffix 7.x` requires Ruby `>= 3.2`. This repo still tests Ruby `2.7`, so the compatible locked resolution is `public_suffix 5.1.1`.

Local validation:
- `mise x node@20.19.0 -- yarn install --frozen-lockfile`
- `mise x ruby@2.7.8 node@20.19.0 -- bundle _2.4.9_ exec rake test`
- `env PACKAGE_JSON_FALLBACK_MANAGER=yarn_classic mise x ruby@2.7.8 node@20.19.0 -- bundle _2.4.9_ exec rake test`
- `mise x node@20.19.0 -- yarn`
- `mise x ruby@2.7.8 node@20.19.0 -- bundle _2.4.9_ exec rake react:update`
- `mise x ruby@2.7.8 node@20.19.0 -- bundle _2.4.9_ exec rake ujs:update`