### PR TITLE
Fix default layout handling for render component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released. Include LINKS for PRs and committers._
 
+#### Fixed
+- Preserve default controller layouts for `render component:` after the Rails 8 render pipeline change reported in #1356.
+
 ## [3.3.0] - 2026-03-31
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes since the last non-beta release.
 _Please add entries here for your pull requests that have not yet been released. Include LINKS for PRs and committers._
 
 #### Fixed
-- Preserve default controller layouts for `render component:` after the Rails 8 render pipeline change reported in #1356.
+- Preserve default controller layouts for `render component:` after the Rails 8 render pipeline change. [PR 1418](https://github.com/reactjs/react-rails/pull/1418) by [justin808](https://github.com/justin808). Fixes [#1356](https://github.com/reactjs/react-rails/issues/1356).
 
 ## [3.3.0] - 2026-03-31
 

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -121,6 +121,7 @@ module React
         versioned_assets.version = [versioned_assets.version, "react-#{react_build}"].compact.join("-")
       end
 
+      # :nodoc:
       def self.component_render_options(options, html)
         render_options = options.merge(inline: html)
         return render_options if render_options.key?(:layout)

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -66,7 +66,7 @@ module React
         ActionController::Renderers.add :component do |component_name, options|
           renderer = ::React::Rails::ControllerRenderer.new(controller: self)
           html = renderer.call(component_name, options)
-          render_options = options.merge(inline: html)
+          render_options = Railtie.send(:component_render_options, options, html)
           render(render_options)
         end
       end
@@ -121,6 +121,13 @@ module React
         versioned_assets.version = [versioned_assets.version, "react-#{react_build}"].compact.join("-")
       end
 
+      def self.component_render_options(options, html)
+        render_options = options.merge(inline: html)
+        return render_options if render_options.key?(:layout)
+
+        render_options.merge(layout: true)
+      end
+
       def self.versioned_assets_for(assets)
         return assets if versioned_assets?(assets)
 
@@ -134,7 +141,7 @@ module React
         assets.respond_to?(:version) && assets.respond_to?(:version=)
       end
 
-      private_class_method :versioned_assets_for, :versioned_assets?
+      private_class_method :component_render_options, :versioned_assets_for, :versioned_assets?
     end
   end
 end

--- a/lib/react/rails/railtie.rb
+++ b/lib/react/rails/railtie.rb
@@ -66,7 +66,7 @@ module React
         ActionController::Renderers.add :component do |component_name, options|
           renderer = ::React::Rails::ControllerRenderer.new(controller: self)
           html = renderer.call(component_name, options)
-          render_options = Railtie.send(:component_render_options, options, html)
+          render_options = Railtie.component_render_options(options, html)
           render(render_options)
         end
       end
@@ -141,7 +141,7 @@ module React
         assets.respond_to?(:version) && assets.respond_to?(:version=)
       end
 
-      private_class_method :component_render_options, :versioned_assets_for, :versioned_assets?
+      private_class_method :versioned_assets_for, :versioned_assets?
     end
   end
 end

--- a/test/react/rails/component_renderer_test.rb
+++ b/test/react/rails/component_renderer_test.rb
@@ -13,6 +13,10 @@ class ComponentRendererController < ActionController::Base
   def explicit_layout_false
     render component: "TodoList", layout: false
   end
+
+  def explicit_named_layout
+    render component: "TodoList", layout: "app_no_turbolinks"
+  end
 end
 
 class ComponentRendererTest < ActionController::TestCase
@@ -34,6 +38,7 @@ class ComponentRendererTest < ActionController::TestCase
     @routes.draw do
       get "default_layout", to: "component_renderer#default_layout"
       get "explicit_layout_false", to: "component_renderer#explicit_layout_false"
+      get "explicit_named_layout", to: "component_renderer#explicit_named_layout"
     end
   end
 
@@ -59,6 +64,19 @@ class ComponentRendererTest < ActionController::TestCase
 
     assert_response :success
     assert_no_match(%r{<title>Dummy</title>}, response.body)
+    assert_match(%r{<main>SSR</main>}, response.body)
+    assert_equal "TodoList", fake_renderer.calls.dig(0, 0)
+  end
+
+  test "render component preserves a named layout override" do # rubocop:disable Minitest/MultipleAssertions
+    fake_renderer = FakeRenderer.new("<main>SSR</main>")
+
+    React::Rails::ControllerRenderer.stub(:new, ->(*) { fake_renderer }) do
+      get :explicit_named_layout
+    end
+
+    assert_response :success
+    assert_match(/app_no_turbolinks/, response.body)
     assert_match(%r{<main>SSR</main>}, response.body)
     assert_equal "TodoList", fake_renderer.calls.dig(0, 0)
   end

--- a/test/react/rails/component_renderer_test.rb
+++ b/test/react/rails/component_renderer_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ComponentRendererController < ActionController::Base
+  append_view_path File.expand_path("../../dummy/app/views", __dir__)
+  layout "application"
+
+  def default_layout
+    render component: "TodoList"
+  end
+
+  def explicit_layout_false
+    render component: "TodoList", layout: false
+  end
+end
+
+class ComponentRendererTest < ActionController::TestCase
+  tests ComponentRendererController
+
+  FakeRenderer = Struct.new(:html, :calls) do
+    def initialize(html)
+      super(html, [])
+    end
+
+    def call(component_name, options)
+      calls << [component_name, options]
+      html
+    end
+  end
+
+  setup do
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw do
+      get "default_layout", to: "component_renderer#default_layout"
+      get "explicit_layout_false", to: "component_renderer#explicit_layout_false"
+    end
+  end
+
+  test "render component uses the current layout by default" do # rubocop:disable Minitest/MultipleAssertions
+    fake_renderer = FakeRenderer.new("<main>SSR</main>")
+
+    React::Rails::ControllerRenderer.stub(:new, ->(*) { fake_renderer }) do
+      get :default_layout
+    end
+
+    assert_response :success
+    assert_match(%r{<title>Dummy</title>}, response.body)
+    assert_match(%r{<main>SSR</main>}, response.body)
+    assert_equal "TodoList", fake_renderer.calls.dig(0, 0)
+  end
+
+  test "render component preserves explicit layout false" do # rubocop:disable Minitest/MultipleAssertions
+    fake_renderer = FakeRenderer.new("<main>SSR</main>")
+
+    React::Rails::ControllerRenderer.stub(:new, ->(*) { fake_renderer }) do
+      get :explicit_layout_false
+    end
+
+    assert_response :success
+    assert_no_match(%r{<title>Dummy</title>}, response.body)
+    assert_match(%r{<main>SSR</main>}, response.body)
+    assert_equal "TodoList", fake_renderer.calls.dig(0, 0)
+  end
+end

--- a/test/react/rails/railtie_test.rb
+++ b/test/react/rails/railtie_test.rb
@@ -50,14 +50,14 @@ class RailtieTest < ActionDispatch::IntegrationTest
     render_options = React::Rails::Railtie.component_render_options({ status: :accepted }, "<div>SSR</div>")
 
     assert_equal "<div>SSR</div>", render_options[:inline]
-    assert render_options[:layout]
+    assert_same true, render_options[:layout]
     assert_equal :accepted, render_options[:status]
   end
 
   test "component render options preserve explicit layout overrides" do
     render_options = React::Rails::Railtie.component_render_options({ layout: false }, "<div>SSR</div>")
 
-    refute render_options[:layout]
+    assert_same false, render_options[:layout]
   end
 
   test "component render options preserve a named layout override" do

--- a/test/react/rails/railtie_test.rb
+++ b/test/react/rails/railtie_test.rb
@@ -45,4 +45,18 @@ class RailtieTest < ActionDispatch::IntegrationTest
       React::Rails::Railtie.append_react_build_to_assets_version!(assets, "development")
     end
   end
+
+  test "component render options default to using the current layout" do
+    render_options = React::Rails::Railtie.send(:component_render_options, { status: :accepted }, "<div>SSR</div>")
+
+    assert_equal "<div>SSR</div>", render_options[:inline]
+    assert render_options[:layout]
+    assert_equal :accepted, render_options[:status]
+  end
+
+  test "component render options preserve explicit layout overrides" do
+    render_options = React::Rails::Railtie.send(:component_render_options, { layout: false }, "<div>SSR</div>")
+
+    refute render_options[:layout]
+  end
 end

--- a/test/react/rails/railtie_test.rb
+++ b/test/react/rails/railtie_test.rb
@@ -47,7 +47,7 @@ class RailtieTest < ActionDispatch::IntegrationTest
   end
 
   test "component render options default to using the current layout" do
-    render_options = React::Rails::Railtie.send(:component_render_options, { status: :accepted }, "<div>SSR</div>")
+    render_options = React::Rails::Railtie.component_render_options({ status: :accepted }, "<div>SSR</div>")
 
     assert_equal "<div>SSR</div>", render_options[:inline]
     assert render_options[:layout]
@@ -55,8 +55,14 @@ class RailtieTest < ActionDispatch::IntegrationTest
   end
 
   test "component render options preserve explicit layout overrides" do
-    render_options = React::Rails::Railtie.send(:component_render_options, { layout: false }, "<div>SSR</div>")
+    render_options = React::Rails::Railtie.component_render_options({ layout: false }, "<div>SSR</div>")
 
     refute render_options[:layout]
+  end
+
+  test "component render options preserve a named layout override" do
+    render_options = React::Rails::Railtie.component_render_options({ layout: "admin" }, "<div>SSR</div>")
+
+    assert_equal "admin", render_options[:layout]
   end
 end


### PR DESCRIPTION
## Summary
- restore the implicit current-layout behavior for `render component:` when no explicit `layout:` option is passed
- preserve explicit layout overrides such as `layout: false`
- add regression coverage for the render-option contract and controller-level layout behavior
- update the changelog for issue #1356

Closes #1356.

## Testing
- `mise exec ruby@3.2.9 -- env BUNDLE_PATH=/Users/justin/codex/react-rails/repo/vendor/bundle bundle exec ruby -Itest test/react/rails/railtie_test.rb`
- `mise exec ruby@3.2.9 -- env BUNDLE_PATH=/Users/justin/codex/react-rails/repo/vendor/bundle bundle exec ruby -Itest test/react/rails/component_renderer_test.rb`
- `mise exec ruby@3.2.9 -- env BUNDLE_GEMFILE=/Users/justin/codex/react-rails/issue-1356/LintingGemfile BUNDLE_PATH=/Users/justin/codex/react-rails/issue-1356/vendor/bundle bundle exec rubocop lib/react/rails/railtie.rb test/react/rails/railtie_test.rb test/react/rails/component_renderer_test.rb`